### PR TITLE
feat: add API key management page and functionality

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ app/
   services/                # Domain services (presence, occupancy, push, messages, weather)
     internal/              # Internal device-count tracking (WardenStore)
     occupancy/             # Web scraping for booking status
-  templates/               # Jinja2 HTML templates (index, auth, notification-create, legal)
+  templates/               # Jinja2 HTML templates (index, auth, notification-create, api-keys, legal)
   static/                  # Served CSS/JS/images frontend assets
 scripts/                   # uv entry points (dev, lint, watch, generate-vapid-keys, …)
 tests/                     # Unit tests; test-data/ holds fixture files

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A FastAPI-based status checker for [Fribbe Beach](https://fribbebeach.de), runni
 - **Occupancy parsing** — Scrapes the Fribbe Beach weekly plan and event calendar to determine booking status for any given date.
 - **Wardens** — Named device watchers that track specific people by MAC address or device name, showing who is currently on-site.
 - **Notifications** — Create and manage Markdown-formatted notifications with optional validity windows. Includes a dedicated builder UI at `/notification-create`.
+- **API key management** — Admin-only web page at `/api-keys` to create, list, and delete API keys without using the REST API or cURL. Accessible via the floating key button on the index page.
 - **Push notifications** — Browser Web Push (VAPID) alerts when someone first arrives at the Fribbe on a given day or when a notification becomes active. Topic-based subscriptions (`presence`, `notifications`).
 - **Weather-aware messages** — Optional OpenWeatherMap integration for temperature- and weather-state-aware status and push messages.
 - **REST API** — JSON API with hybrid authentication (API key header or opaque server-side session cookie). Interactive docs at `/docs`.

--- a/app/api/access_role.py
+++ b/app/api/access_role.py
@@ -11,3 +11,7 @@ class AccessRole(IntEnum):
     READER = 100
     NOTIFICATION_OPERATOR = 200
     ADMIN = 300
+
+    def display_name(self) -> str:
+        """Return a human-friendly display name for this role."""
+        return self.name.replace("_", " ").title()

--- a/app/api/access_role.py
+++ b/app/api/access_role.py
@@ -8,6 +8,6 @@ class AccessRole(IntEnum):
     all permissions of lower roles.
     """
 
-    READER = 1
-    NOTIFICATION_OPERATOR = 2
-    ADMIN = 3
+    READER = 100
+    NOTIFICATION_OPERATOR = 200
+    ADMIN = 300

--- a/app/api/requests.py
+++ b/app/api/requests.py
@@ -141,7 +141,7 @@ class PatchPushTopicsRequest(BaseModel):
 class CreateApiKeyRequest(BaseModel):
     """Request body for creating a new API key."""
 
-    comment: str = Field(..., min_length=env.COMMENT_MIN_LENGTH, max_length=env.COMMENT_MAX_LENGTH)
+    comment: str = Field(..., min_length=env.API_KEY_COMMENT_MIN_LENGTH, max_length=env.API_KEY_COMMENT_MAX_LENGTH)
     valid_until: datetime | None = None
     role: AccessRole = AccessRole.READER
 

--- a/app/api/requests.py
+++ b/app/api/requests.py
@@ -141,7 +141,7 @@ class PatchPushTopicsRequest(BaseModel):
 class CreateApiKeyRequest(BaseModel):
     """Request body for creating a new API key."""
 
-    comment: str = ""
+    comment: str = Field(..., min_length=env.COMMENT_MIN_LENGTH, max_length=env.COMMENT_MAX_LENGTH)
     valid_until: datetime | None = None
     role: AccessRole = AccessRole.READER
 

--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -77,7 +77,7 @@ class ApiKey(BaseModel):
     """An API key with metadata."""
 
     key: str = Field(..., min_length=env.MIN_TOKEN_LENGTH)
-    comment: str = Field(..., max_length=env.COMMENT_MAX_LENGTH)
+    comment: str = Field(..., max_length=env.API_KEY_COMMENT_MAX_LENGTH)
     valid_until: datetime
     role: AccessRole = AccessRole.ADMIN
 
@@ -125,7 +125,7 @@ class MaskedApiKey(BaseModel):
     """API key with the raw value replaced by a short prefix."""
 
     key_prefix: str
-    comment: str = Field(..., max_length=env.COMMENT_MAX_LENGTH)
+    comment: str = Field(..., max_length=env.API_KEY_COMMENT_MAX_LENGTH)
     valid_until: datetime
     role: AccessRole
 

--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -79,7 +79,7 @@ class ApiKey(BaseModel):
     key: str = Field(..., min_length=env.MIN_TOKEN_LENGTH)
     comment: str = Field(..., max_length=env.API_KEY_COMMENT_MAX_LENGTH)
     valid_until: datetime
-    role: AccessRole = AccessRole.ADMIN
+    role: AccessRole = AccessRole.READER
 
     @staticmethod
     def generate_new(comment: str, valid_until: datetime, role: AccessRole = AccessRole.READER) -> "ApiKey":

--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -77,7 +77,7 @@ class ApiKey(BaseModel):
     """An API key with metadata."""
 
     key: str = Field(..., min_length=env.MIN_TOKEN_LENGTH)
-    comment: str
+    comment: str = Field(..., max_length=200)
     valid_until: datetime
     role: AccessRole = AccessRole.ADMIN
 
@@ -96,12 +96,19 @@ class ApiKey(BaseModel):
     @classmethod
     def from_dict(cls, d: dict[str, str]) -> Self:
         """Deserialize from a plain dict."""
-        role_str = d.get("role", "reader")
+        raw_role = d.get("role")
+        if isinstance(raw_role, int) or (isinstance(raw_role, str) and raw_role.isdigit()):
+            role = AccessRole(int(raw_role))
+        elif isinstance(raw_role, str):
+            # Legacy: stored by name (e.g. "reader"). Fall back to READER on unknown names.
+            role = next((r for r in AccessRole if r.name.lower() == raw_role.lower()), AccessRole.READER)
+        else:
+            role = AccessRole.READER
         return cls(
             key=d["key"],
             comment=d["comment"],
             valid_until=datetime.fromisoformat(d["valid_until"]),
-            role=AccessRole[role_str.upper()],
+            role=role,
         )
 
     def to_dict(self) -> dict[str, str]:
@@ -110,7 +117,7 @@ class ApiKey(BaseModel):
             "key": self.key,
             "comment": self.comment,
             "valid_until": self.valid_until.isoformat(),
-            "role": self.role.name.lower(),
+            "role": str(self.role.value),
         }
 
 
@@ -118,7 +125,7 @@ class MaskedApiKey(BaseModel):
     """API key with the raw value replaced by a short prefix."""
 
     key_prefix: str
-    comment: str
+    comment: str = Field(..., max_length=200)
     valid_until: datetime
     role: AccessRole
 
@@ -126,17 +133,24 @@ class MaskedApiKey(BaseModel):
     def from_api_key(api_key: "ApiKey") -> "MaskedApiKey":
         """Create a masked representation of the given API key."""
         return MaskedApiKey(
-            key_prefix=api_key.key[: env.MIN_KEY_PREFIX_LENGTH] + "...",
+            key_prefix=MaskedApiKey.get_masked_prefix(api_key.key),
             comment=api_key.comment,
             valid_until=api_key.valid_until,
             role=api_key.role,
         )
+
+    @staticmethod
+    def get_masked_prefix(key: str) -> str:
+        """Get the masked prefix for a given API key value."""
+        return key[: env.MIN_KEY_PREFIX_LENGTH] + "..."
 
 
 class ApiKeys(BaseModel):
     """Wrapper for a list of masked API keys."""
 
     api_keys: list[MaskedApiKey]
+    self_key_prefix: str | None = None
+    admin_token_prefix: str | None = None
 
 
 class PostNotificationResponse(BaseModel):

--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -125,7 +125,7 @@ class MaskedApiKey(BaseModel):
     """API key with the raw value replaced by a short prefix."""
 
     key_prefix: str
-    comment: str = Field(..., max_length=200)
+    comment: str = Field(..., max_length=env.COMMENT_MAX_LENGTH)
     valid_until: datetime
     role: AccessRole
 

--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -77,7 +77,7 @@ class ApiKey(BaseModel):
     """An API key with metadata."""
 
     key: str = Field(..., min_length=env.MIN_TOKEN_LENGTH)
-    comment: str = Field(..., max_length=200)
+    comment: str = Field(..., max_length=env.COMMENT_MAX_LENGTH)
     valid_until: datetime
     role: AccessRole = AccessRole.ADMIN
 

--- a/app/env.py
+++ b/app/env.py
@@ -31,6 +31,12 @@ TOAST_DISPLAY_SECONDS: int = 3
 
 CONTENT_HASH_VERSION: str = get_content_hash_version()
 
+DEFAULT_API_KEY_VALIDITY_DAYS: int = 90
+
+# Validation constraints for API key comment field.
+COMMENT_MIN_LENGTH: int = 3
+COMMENT_MAX_LENGTH: int = 200
+
 
 # ---------------------------------------------------------------------------
 # Required

--- a/app/env.py
+++ b/app/env.py
@@ -34,8 +34,8 @@ CONTENT_HASH_VERSION: str = get_content_hash_version()
 DEFAULT_API_KEY_VALIDITY_DAYS: int = 90
 
 # Validation constraints for API key comment field.
-COMMENT_MIN_LENGTH: int = 3
-COMMENT_MAX_LENGTH: int = 200
+API_KEY_COMMENT_MIN_LENGTH: int = 3
+API_KEY_COMMENT_MAX_LENGTH: int = 200
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/_page_utils.py
+++ b/app/routers/_page_utils.py
@@ -22,12 +22,16 @@ def _base_context(request: Request) -> dict[str, object]:
         "url_auth": Route.URL_AUTH,
         "url_signout": Route.URL_SIGNOUT,
         "url_notification_create": Route.URL_NOTIFICATION_CREATE,
+        "url_api_keys": Route.URL_API_KEYS,
         "url_preview": f"{Route.URL_NOTIFICATION_PREVIEW}?n_ids={NotificationFilterId.ALL_ACTIVE}",
         "url_notification_preview": Route.URL_NOTIFICATION_PREVIEW,
         # HTML fragment URLs (polled by JS)
         "url_status_content": Route.URL_STATUS_CONTENT,
         "url_notifications_content": Route.URL_NOTIFICATIONS_CONTENT,
         "url_notification_preview_content": Route.URL_NOTIFICATION_PREVIEW_CONTENT,
+        # API endpoints (used by API key management page)
+        "url_api_internal_api_keys": "/api/internal/api_keys",
+        "url_api_internal_api_key": "/api/internal/api_key",
         # API URLs (called from JS)
         "url_api_push_vapid_key": Route.URL_API_PUSH_VAPID_KEY,
         "url_api_push_status": Route.URL_API_PUSH_STATUS,

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -63,7 +63,7 @@ def delete_api_key(
         raise HTTPException(status_code=403, detail="Cannot delete your own API key")
     result = EphemeralAPIKeyStore.remove(request.key)
     if result == RemoveResult.NOT_FOUND:
-        raise HTTPException(status_code=404, detail="Api key not found")
+        raise HTTPException(status_code=404, detail="API key not found")
     if result == RemoveResult.AMBIGUOUS:
         raise HTTPException(status_code=409, detail="Ambiguous key prefix: multiple matches found")
 

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -31,8 +31,8 @@ def create_api_key(
 
     Require valid API key to create or no API keys to begin with at all (admin setup mode).
 
-    - comment: Optional comment for the key
-    - valid_until: Optional datetime (default: 6 months from now).
+    - comment: Required comment for the key. Length constraints are validated by `CreateApiKeyRequest`.
+    - valid_until: Optional datetime. Defaults to now plus `env.DEFAULT_API_KEY_VALIDITY_DAYS`.
     """
     valid_until = (
         request.valid_until or datetime.now(tz=ZoneInfo(env.TZ)) + timedelta(days=env.DEFAULT_API_KEY_VALIDITY_DAYS)

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -56,7 +56,10 @@ def delete_api_key(
     auth_subject: Annotated[str, Depends(HybridAuth(min_role=AccessRole.ADMIN))],
 ) -> None:
     """Delete an API key by its value or prefix (at least 5 characters). Only delete if there is a unique match."""
-    if auth_subject.startswith(request.key) or request.key.startswith(auth_subject):
+    authenticated_with_stored_key = EphemeralAPIKeyStore.get_valid_key_role(auth_subject) is not None
+    if authenticated_with_stored_key and (
+        auth_subject.startswith(request.key) or request.key.startswith(auth_subject)
+    ):
         raise HTTPException(status_code=403, detail="Cannot delete your own API key")
     result = EphemeralAPIKeyStore.remove(request.key)
     if result == RemoveResult.NOT_FOUND:

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -57,9 +57,7 @@ def delete_api_key(
 ) -> None:
     """Delete an API key by its value or prefix (at least 5 characters). Only delete if there is a unique match."""
     authenticated_with_stored_key = EphemeralAPIKeyStore.get_valid_key_role(auth_subject) is not None
-    if authenticated_with_stored_key and (
-        auth_subject.startswith(request.key) or request.key.startswith(auth_subject)
-    ):
+    if authenticated_with_stored_key and (auth_subject.startswith(request.key) or request.key.startswith(auth_subject)):
         raise HTTPException(status_code=403, detail="Cannot delete your own API key")
     result = EphemeralAPIKeyStore.remove(request.key)
     if result == RemoveResult.NOT_FOUND:

--- a/app/routers/api_keys.py
+++ b/app/routers/api_keys.py
@@ -34,7 +34,9 @@ def create_api_key(
     - comment: Optional comment for the key
     - valid_until: Optional datetime (default: 6 months from now).
     """
-    valid_until = (request.valid_until or datetime.now(tz=ZoneInfo(env.TZ)) + timedelta(days=180)).replace(
+    valid_until = (
+        request.valid_until or datetime.now(tz=ZoneInfo(env.TZ)) + timedelta(days=env.DEFAULT_API_KEY_VALIDITY_DAYS)
+    ).replace(
         microsecond=0,
     )
     new_api_key = ApiKey.generate_new(request.comment, valid_until, request.role)
@@ -51,9 +53,11 @@ def create_api_key(
 )
 def delete_api_key(
     request: DeleteApiKeyRequest,
-    _: Annotated[str, Depends(HybridAuth(min_role=AccessRole.ADMIN))],
+    auth_subject: Annotated[str, Depends(HybridAuth(min_role=AccessRole.ADMIN))],
 ) -> None:
     """Delete an API key by its value or prefix (at least 5 characters). Only delete if there is a unique match."""
+    if auth_subject.startswith(request.key) or request.key.startswith(auth_subject):
+        raise HTTPException(status_code=403, detail="Cannot delete your own API key")
     result = EphemeralAPIKeyStore.remove(request.key)
     if result == RemoveResult.NOT_FOUND:
         raise HTTPException(status_code=404, detail="Api key not found")
@@ -65,7 +69,21 @@ def delete_api_key(
     "/api_keys",
     openapi_extra=requires_auth_extra(),
 )
-def list_api_keys(_: Annotated[str | None, Depends(HybridAuth(min_role=AccessRole.ADMIN))]) -> ApiKeys:
+def list_api_keys(auth_subject: Annotated[str | None, Depends(HybridAuth(min_role=AccessRole.ADMIN))]) -> ApiKeys:
     """Return all API keys as a masked list. Full key values are only shown at creation time."""
     keys = EphemeralAPIKeyStore.load()
-    return ApiKeys(api_keys=[MaskedApiKey.from_api_key(k) for k in keys])
+    self_prefix = _resolve_self_prefix(auth_subject, keys) if auth_subject else None
+    admin_prefix = MaskedApiKey.get_masked_prefix(env.ADMIN_TOKEN) if env.ADMIN_TOKEN else None
+    return ApiKeys(
+        api_keys=[MaskedApiKey.from_api_key(k) for k in keys],
+        self_key_prefix=self_prefix,
+        admin_token_prefix=admin_prefix,
+    )
+
+
+def _resolve_self_prefix(auth_subject: str, keys: list[ApiKey]) -> str | None:
+    """Return the masked prefix for the caller's own key, or None if authenticated via ADMIN_TOKEN."""
+    for k in keys:
+        if k.key == auth_subject:
+            return MaskedApiKey.from_api_key(k).key_prefix
+    return None

--- a/app/routers/nav_context.py
+++ b/app/routers/nav_context.py
@@ -29,6 +29,7 @@ class Route(StrEnum):
     URL_SIGNOUT = "/signout"
     URL_NOTIFICATION_CREATE = "/notification-create"
     URL_NOTIFICATION_PREVIEW = "/preview/notifications"
+    URL_API_KEYS = "/api-keys"
 
     # HTML fragment routes (polled by JS)
     URL_STATUS_CONTENT = "/status/content"
@@ -118,6 +119,7 @@ class NavContext(Mapping[str, object]):
     request: InitVar[Request]
     show_auth_button: bool | NavPredicate = False
     show_notification_create_btn: bool | NavPredicate = False
+    show_api_keys_btn: bool | NavPredicate = False
     show_preview_btn: bool | NavPredicate = False
     role: AccessRole | None = field(init=False)
     signed_in: bool = field(init=False)
@@ -129,6 +131,7 @@ class NavContext(Mapping[str, object]):
         self.signed_in = self.role is not None
         self.show_auth_button = _resolve_predicate(val=self.show_auth_button, role=self.role)
         self.show_notification_create_btn = _resolve_predicate(val=self.show_notification_create_btn, role=self.role)
+        self.show_api_keys_btn = _resolve_predicate(val=self.show_api_keys_btn, role=self.role)
         self.show_preview_btn = _resolve_predicate(val=self.show_preview_btn, role=self.role)
         self.show_back_btn = request.url.path not in {Route.URL_INDEX, Route.URL_AUTH}
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -205,8 +205,8 @@ def get_api_keys_page(
         show_auth_button=False,
         show_api_keys_btn=False,
     )
-    roles = [{"value": r.value, "label": r.name.replace("_", " ").title()} for r in AccessRole]
-    role_labels = {r.value: r.name.replace("_", " ").title() for r in AccessRole}
+    roles = [{"value": r.value, "label": r.display_name()} for r in AccessRole]
+    role_labels = {r.value: r.display_name() for r in AccessRole}
     return templates.TemplateResponse(
         request,
         "api-keys.html",
@@ -214,8 +214,9 @@ def get_api_keys_page(
             **nav_ctx,
             "roles": roles,
             "role_labels": role_labels,
+            "admin_role_label": AccessRole.ADMIN.display_name(),
             "default_validity_days": env.DEFAULT_API_KEY_VALIDITY_DAYS,
-            "comment_min_length": env.COMMENT_MIN_LENGTH,
-            "comment_max_length": env.COMMENT_MAX_LENGTH,
+            "comment_min_length": env.API_KEY_COMMENT_MIN_LENGTH,
+            "comment_max_length": env.API_KEY_COMMENT_MAX_LENGTH,
         },
     )

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -6,7 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from app import env
+from app.api.access_role import AccessRole
 from app.api.ephemeral_api_key_store import EphemeralAPIKeyStore
+from app.api.hybrid_auth import PageAuth
 from app.api.requests import AuthRedirectQuery
 from app.dependencies import (
     MessageServiceDep,
@@ -16,7 +18,7 @@ from app.dependencies import (
 )
 from app.format import seconds_to_human
 from app.routers._page_utils import templates
-from app.routers.nav_context import NavContext, Route, operator_or_above
+from app.routers.nav_context import NavContext, Route, admin, operator_or_above
 from app.services.datetime_parser import format_date_long, format_datetime
 from app.services.occupancy.model import OccupancySource, OccupancyType
 from app.services.presence_level import PresenceLevel
@@ -33,6 +35,7 @@ def get_html(request: Request, for_date: str | None = None) -> HTMLResponse:
         request,
         show_auth_button=env.is_login_button_enabled(),
         show_notification_create_btn=operator_or_above,
+        show_api_keys_btn=admin,
         show_preview_btn=operator_or_above,
     )
     _today = datetime.now(tz=ZoneInfo(env.TZ)).date()
@@ -188,4 +191,31 @@ def get_auth_page(request: Request, redirect: Annotated[AuthRedirectQuery, Depen
         request,
         "auth.html",
         context={**nav_ctx, "next_url": redirect.next},
+    )
+
+
+@router.get(Route.URL_API_KEYS, response_class=HTMLResponse, tags=["HTML"])
+def get_api_keys_page(
+    request: Request,
+    _: Annotated[str, Depends(PageAuth(min_role=AccessRole.ADMIN))],
+) -> HTMLResponse:
+    """Serve the API key management page."""
+    nav_ctx = NavContext(
+        request,
+        show_auth_button=False,
+        show_api_keys_btn=False,
+    )
+    roles = [{"value": r.value, "label": r.name.replace("_", " ").title()} for r in AccessRole]
+    role_labels = {r.value: r.name.replace("_", " ").title() for r in AccessRole}
+    return templates.TemplateResponse(
+        request,
+        "api-keys.html",
+        context={
+            **nav_ctx,
+            "roles": roles,
+            "role_labels": role_labels,
+            "default_validity_days": env.DEFAULT_API_KEY_VALIDITY_DAYS,
+            "comment_min_length": env.COMMENT_MIN_LENGTH,
+            "comment_max_length": env.COMMENT_MAX_LENGTH,
+        },
     )

--- a/app/static/css/api-keys.styles.css
+++ b/app/static/css/api-keys.styles.css
@@ -264,6 +264,29 @@ button.secondary:hover {
     color: var(--danger-text);
 }
 
+.key-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.key-table th.sortable::after {
+    content: ' ⇅';
+    opacity: 0.35;
+    font-size: 0.78em;
+    font-style: normal;
+}
+
+.key-table th.sortable[aria-sort="ascending"]::after {
+    content: ' ▲';
+    opacity: 1;
+}
+
+.key-table th.sortable[aria-sort="descending"]::after {
+    content: ' ▼';
+    opacity: 1;
+}
+
 .delete-btn {
     appearance: none;
     border: none;

--- a/app/static/css/api-keys.styles.css
+++ b/app/static/css/api-keys.styles.css
@@ -1,0 +1,363 @@
+:root {
+    --bg-input: #fafafa;
+    --text-input: #333;
+    --accent: #4caf50;
+    --accent-hover: #43a047;
+    --danger: #c62828;
+    --danger-hover: #b71c1c;
+    --danger-bg: #ffebee;
+    --danger-text: #c62828;
+    --muted: #888;
+    --bg-banner: #e8f5e9;
+    --text-banner: #2e7d32;
+    --border-banner: #a5d6a7;
+    --bg-overlay: rgba(0, 0, 0, 0.45);
+    --bg-dialog: #fff;
+}
+
+html.dark-mode {
+    --bg-input: #2a2a2a;
+    --text-input: #e0e0e0;
+    --danger-bg: #3d1c1c;
+    --danger-text: #ef9a9a;
+    --bg-banner: #1a3d1c;
+    --text-banner: #81c784;
+    --border-banner: #2e7d32;
+    --bg-overlay: rgba(0, 0, 0, 0.7);
+    --bg-dialog: #252525;
+}
+
+body {
+    color: var(--text-body);
+    line-height: 1.6;
+}
+
+.container {
+    padding: 24px 20px 32px;
+    text-align: left;
+}
+
+h1 {
+    margin-bottom: 6px;
+    text-align: center;
+}
+
+.subtitle {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    margin-top: 0;
+    margin-bottom: 24px;
+}
+
+.card {
+    margin-bottom: 24px;
+}
+
+.card h2 {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--text-heading);
+    margin: 0 0 16px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-row {
+    display: flex;
+    gap: 16px;
+}
+
+.form-row .form-group {
+    flex: 1;
+}
+
+.field-hint {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.82rem;
+    color: var(--text-body);
+    opacity: 0.7;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 500;
+    font-size: 0.92rem;
+    color: var(--text-body);
+}
+
+input[type="text"],
+input[type="datetime-local"],
+select {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--border-input);
+    border-radius: 8px;
+    box-sizing: border-box;
+    font-family: 'Roboto', sans-serif;
+    font-size: 0.95rem;
+    color: var(--text-input);
+    background: var(--bg-input);
+    transition: border-color 0.2s;
+}
+
+input:focus,
+select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.15);
+}
+
+button.primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    appearance: none;
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    padding: 10px 20px;
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 500;
+    background: var(--accent);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+button.primary:hover {
+    background: var(--accent-hover);
+}
+
+button.primary:disabled {
+    cursor: wait;
+    opacity: 0.6;
+}
+
+button.primary svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+button.primary.danger {
+    background: var(--danger);
+    border-color: var(--danger);
+}
+
+button.primary.danger:hover {
+    background: var(--danger-hover);
+}
+
+button.secondary {
+    appearance: none;
+    border: 1px solid var(--border-control);
+    border-radius: 8px;
+    padding: 10px 20px;
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 500;
+    background: var(--bg-control);
+    color: var(--text-control);
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+button.secondary:hover {
+    background: var(--bg-control-hover);
+}
+
+/* New key banner */
+.new-key-banner {
+    background: var(--bg-banner);
+    border: 1px solid var(--border-banner);
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin-bottom: 24px;
+}
+
+.new-key-label {
+    margin: 0 0 8px;
+    font-weight: 500;
+    font-size: 0.92rem;
+    color: var(--text-banner);
+}
+
+.new-key-value-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.new-key-value-row code {
+    flex: 1;
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-panel);
+    border-radius: 6px;
+    font-size: 0.88rem;
+    word-break: break-all;
+    color: var(--text-body);
+}
+
+.copy-btn {
+    appearance: none;
+    border: 1px solid var(--border-control);
+    border-radius: 6px;
+    padding: 6px 8px;
+    background: var(--bg-control);
+    color: var(--text-control);
+    cursor: pointer;
+    transition: background 0.2s;
+    flex-shrink: 0;
+}
+
+.copy-btn:hover {
+    background: var(--bg-control-hover);
+}
+
+.copy-btn svg {
+    width: 18px;
+    height: 18px;
+    display: block;
+}
+
+/* Key table */
+.key-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+.key-table th {
+    text-align: left;
+    font-weight: 500;
+    padding: 8px 10px;
+    border-bottom: 2px solid var(--border-subtle);
+    color: var(--text-muted);
+    font-size: 0.84rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.key-table td {
+    padding: 10px;
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-body);
+    vertical-align: middle;
+}
+
+.key-table tr:last-child td {
+    border-bottom: none;
+}
+
+.key-table .key-prefix {
+    font-family: monospace;
+    font-size: 0.9rem;
+}
+
+.key-table .expired {
+    color: var(--danger-text);
+}
+
+.delete-btn {
+    appearance: none;
+    border: none;
+    background: none;
+    color: var(--danger-text);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background 0.2s;
+    display: inline-flex;
+}
+
+.delete-btn:hover {
+    background: var(--danger-bg);
+}
+
+.delete-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.self-hint {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.loading-hint,
+.empty-hint {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    padding: 8px 0;
+}
+
+/* Confirmation overlay */
+.confirm-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9000;
+    background: var(--bg-overlay);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.confirm-dialog {
+    background: var(--bg-dialog);
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    max-width: 400px;
+    width: 90%;
+}
+
+.confirm-dialog p {
+    margin: 0 0 18px;
+    font-size: 0.98rem;
+    color: var(--text-body);
+}
+
+.confirm-dialog .actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+.role-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+@media (max-width: 600px) {
+    .form-row {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .key-table th:nth-child(4),
+    .key-table td:nth-child(4) {
+        display: none;
+    }
+}
+
+/* Dark mode toggle button — size overrides */
+.theme-toggle-btn {
+    width: 32px;
+    height: 32px;
+}
+
+.theme-toggle-btn svg {
+    width: 16px;
+    height: 16px;
+}

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -1,4 +1,4 @@
-/* Shared styles — used on all pages */
+/* Base styles — used on all pages (loaded via base.html) */
 
 :root {
     --color-red: #f44336;
@@ -73,6 +73,13 @@ html.dark-mode {
         --border-light-ring: #1e1e1e;
     }
     
+    /* Clipboard fallback textarea — positioned off-screen to avoid flash */
+    .clipboard-textarea {
+        position: fixed;
+        left: -9999px;
+        top: -9999px;
+    }
+
     .hidden {
         display: none !important;
     }

--- a/app/static/css/index.styles.css
+++ b/app/static/css/index.styles.css
@@ -1,11 +1,5 @@
 /* Index page styles */
 
-.clipboard-textarea {
-    position: fixed;
-    left: -9999px;
-    top: -9999px;
-}
-
 .occupancy-list {
     margin: 0;
     padding-left: 24px;

--- a/app/static/js/api-keys.js
+++ b/app/static/js/api-keys.js
@@ -251,7 +251,7 @@
             })
             .catch(function () {
                 hideDeleteConfirm();
-                alert('Fehler beim Löschen des Schlüssels.');
+                showToast('Fehler beim Löschen des Schlüssels.', 'error');
             });
     }
 
@@ -262,6 +262,7 @@
         var maxLen = parseInt(commentInput.getAttribute('maxlength') || '9999', 10);
         if (comment.length < minLen || comment.length > maxLen) {
             commentInput.focus();
+            showToast('Kommentar muss zwischen ' + minLen + ' und ' + maxLen + ' Zeichen lang sein.', 'error');
             return;
         }
         createBtn.disabled = true;

--- a/app/static/js/api-keys.js
+++ b/app/static/js/api-keys.js
@@ -5,6 +5,7 @@
     var apiKeysUrl = body.getAttribute('data-url-api-keys');
     var apiKeyUrl = body.getAttribute('data-url-api-key');
     var ROLE_LABELS = JSON.parse(body.getAttribute('data-role-labels') || '{}');
+    var adminRoleLabel = body.getAttribute('data-role-label-admin');
 
     var form = document.getElementById('create-key-form');
     var createBtn = document.getElementById('create-key-btn');
@@ -28,6 +29,10 @@
 
     var pendingDeletePrefix = '';
     var selfKeyPrefix = null;
+    var currentKeys = [];
+    var currentAdminPrefix = null;
+    var sortColumn = null;
+    var sortDir = 'asc';
 
     function formatDate(isoStr) {
         try {
@@ -62,11 +67,58 @@
             .then(function (data) {
                 keyListLoading.classList.add('hidden');
                 selfKeyPrefix = data.self_key_prefix || null;
-                renderKeys(data.api_keys || [], data.admin_token_prefix || null);
+                currentKeys = data.api_keys || [];
+                currentAdminPrefix = data.admin_token_prefix || null;
+                renderKeys(sortedKeys(), currentAdminPrefix);
             })
             .catch(function () {
                 keyListLoading.textContent = 'Fehler beim Laden der Schlüssel.';
             });
+    }
+
+    function sortedKeys() {
+        if (!sortColumn) return currentKeys.slice();
+        return currentKeys.slice().sort(function (a, b) {
+            var av, bv;
+            if (sortColumn === 'role') {
+                av = a.role || 0;
+                bv = b.role || 0;
+            } else {
+                av = a.valid_until ? new Date(a.valid_until).getTime() : Infinity;
+                bv = b.valid_until ? new Date(b.valid_until).getTime() : Infinity;
+            }
+            if (av < bv) return sortDir === 'asc' ? -1 : 1;
+            if (av > bv) return sortDir === 'asc' ? 1 : -1;
+            return 0;
+        });
+    }
+
+    function updateSortHeaders() {
+        var headers = keyListTable.querySelectorAll('th[data-sort]');
+        headers.forEach(function (th) {
+            if (th.getAttribute('data-sort') === sortColumn) {
+                th.setAttribute('aria-sort', sortDir === 'asc' ? 'ascending' : 'descending');
+            } else {
+                th.setAttribute('aria-sort', 'none');
+            }
+        });
+    }
+
+    function setupSortHeaders() {
+        var headers = keyListTable.querySelectorAll('th[data-sort]');
+        headers.forEach(function (th) {
+            th.addEventListener('click', function () {
+                var col = th.getAttribute('data-sort');
+                if (sortColumn === col) {
+                    sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+                } else {
+                    sortColumn = col;
+                    sortDir = 'asc';
+                }
+                updateSortHeaders();
+                renderKeys(sortedKeys(), currentAdminPrefix);
+            });
+        });
     }
 
     function renderAdminTokenRow(prefix) {
@@ -79,13 +131,13 @@
         tr.appendChild(tdPrefix);
 
         var tdComment = document.createElement('td');
-        tdComment.textContent = 'Admin-Token (Umgebungsvariable)';
+        tdComment.textContent = 'Admin-Token';
         tr.appendChild(tdComment);
 
         var tdRole = document.createElement('td');
         var badge = document.createElement('span');
         badge.className = 'role-badge';
-        badge.textContent = ROLE_LABELS[3] || 'Admin';
+        badge.textContent = adminRoleLabel;
         tdRole.appendChild(badge);
         tr.appendChild(tdRole);
 
@@ -263,6 +315,7 @@
         if (e.target === deleteOverlay) hideDeleteConfirm();
     });
 
-    // Initial load
+    // Setup sort headers and initial load
+    setupSortHeaders();
     loadKeys();
 })();

--- a/app/static/js/api-keys.js
+++ b/app/static/js/api-keys.js
@@ -1,0 +1,268 @@
+(function () {
+    'use strict';
+
+    var body = document.body;
+    var apiKeysUrl = body.getAttribute('data-url-api-keys');
+    var apiKeyUrl = body.getAttribute('data-url-api-key');
+    var ROLE_LABELS = JSON.parse(body.getAttribute('data-role-labels') || '{}');
+
+    var form = document.getElementById('create-key-form');
+    var createBtn = document.getElementById('create-key-btn');
+    var commentInput = document.getElementById('key-comment');
+    var roleSelect = document.getElementById('key-role');
+    var validUntilInput = document.getElementById('key-valid-until');
+
+    var newKeyBanner = document.getElementById('new-key-banner');
+    var newKeyValue = document.getElementById('new-key-value');
+    var copyKeyBtn = document.getElementById('copy-key-btn');
+
+    var keyListLoading = document.getElementById('key-list-loading');
+    var keyListEmpty = document.getElementById('key-list-empty');
+    var keyListTable = document.getElementById('key-list-table');
+    var keyListBody = document.getElementById('key-list-body');
+
+    var deleteOverlay = document.getElementById('delete-confirm-overlay');
+    var deletePrefix = document.getElementById('delete-confirm-prefix');
+    var deleteYes = document.getElementById('delete-confirm-yes');
+    var deleteNo = document.getElementById('delete-confirm-no');
+
+    var pendingDeletePrefix = '';
+    var selfKeyPrefix = null;
+
+    function formatDate(isoStr) {
+        try {
+            var d = new Date(isoStr);
+            return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+        } catch (_e) {
+            return isoStr;
+        }
+    }
+
+    function isExpired(isoStr) {
+        try {
+            return new Date(isoStr) < new Date();
+        } catch (_e) {
+            return false;
+        }
+    }
+
+    function loadKeys() {
+        keyListLoading.classList.remove('hidden');
+        keyListEmpty.classList.add('hidden');
+        keyListTable.classList.add('hidden');
+
+        fetch(apiKeysUrl, {
+            headers: withCsrfHeaders({ 'Accept': 'application/json' }),
+            credentials: 'same-origin'
+        })
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (data) {
+                keyListLoading.classList.add('hidden');
+                selfKeyPrefix = data.self_key_prefix || null;
+                renderKeys(data.api_keys || [], data.admin_token_prefix || null);
+            })
+            .catch(function () {
+                keyListLoading.textContent = 'Fehler beim Laden der Schlüssel.';
+            });
+    }
+
+    function renderAdminTokenRow(prefix) {
+        var tr = document.createElement('tr');
+        tr.className = 'admin-token-row';
+
+        var tdPrefix = document.createElement('td');
+        tdPrefix.className = 'key-prefix';
+        tdPrefix.textContent = prefix;
+        tr.appendChild(tdPrefix);
+
+        var tdComment = document.createElement('td');
+        tdComment.textContent = 'Admin-Token (Umgebungsvariable)';
+        tr.appendChild(tdComment);
+
+        var tdRole = document.createElement('td');
+        var badge = document.createElement('span');
+        badge.className = 'role-badge';
+        badge.textContent = ROLE_LABELS[3] || 'Admin';
+        tdRole.appendChild(badge);
+        tr.appendChild(tdRole);
+
+        var tdValid = document.createElement('td');
+        tdValid.textContent = '—';
+        tr.appendChild(tdValid);
+
+        var tdActions = document.createElement('td');
+        var hint = document.createElement('span');
+        hint.className = 'self-hint';
+        hint.textContent = '(env)';
+        tdActions.appendChild(hint);
+        tr.appendChild(tdActions);
+
+        keyListBody.appendChild(tr);
+    }
+
+    function renderKeys(keys, adminTokenPrefix) {
+        keyListBody.innerHTML = '';
+        if (adminTokenPrefix) {
+            renderAdminTokenRow(adminTokenPrefix);
+        }
+        if (keys.length === 0 && !adminTokenPrefix) {
+            keyListEmpty.classList.remove('hidden');
+            keyListTable.classList.add('hidden');
+            return;
+        }
+        keyListEmpty.classList.add('hidden');
+        keyListTable.classList.remove('hidden');
+
+        keys.forEach(function (k) {
+            var tr = document.createElement('tr');
+            var expired = isExpired(k.valid_until);
+
+            var tdPrefix = document.createElement('td');
+            tdPrefix.className = 'key-prefix';
+            tdPrefix.textContent = k.key_prefix;
+            tr.appendChild(tdPrefix);
+
+            var tdComment = document.createElement('td');
+            tdComment.textContent = k.comment || '—';
+            tr.appendChild(tdComment);
+
+            var tdRole = document.createElement('td');
+            var badge = document.createElement('span');
+            badge.className = 'role-badge';
+            badge.textContent = ROLE_LABELS[k.role] || k.role;
+            tdRole.appendChild(badge);
+            tr.appendChild(tdRole);
+
+            var tdValid = document.createElement('td');
+            tdValid.textContent = formatDate(k.valid_until);
+            if (expired) tdValid.className = 'expired';
+            tr.appendChild(tdValid);
+
+            var tdActions = document.createElement('td');
+            var isSelf = selfKeyPrefix && k.key_prefix === selfKeyPrefix;
+            if (isSelf) {
+                var selfHint = document.createElement('span');
+                selfHint.className = 'self-hint';
+                selfHint.textContent = '(eigener)';
+                tdActions.appendChild(selfHint);
+            } else {
+                var deleteBtn = document.createElement('button');
+                deleteBtn.className = 'delete-btn';
+                deleteBtn.title = 'Löschen';
+                deleteBtn.setAttribute('aria-label', 'Schlüssel löschen');
+                deleteBtn.innerHTML =
+                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+                    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+                    '<polyline points="3 6 5 6 21 6"/>' +
+                    '<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>' +
+                    '<path d="M10 11v6"/><path d="M14 11v6"/>' +
+                    '<path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>' +
+                    '</svg>';
+                deleteBtn.addEventListener('click', function () {
+                    showDeleteConfirm(k.key_prefix);
+                });
+                tdActions.appendChild(deleteBtn);
+            }
+            tr.appendChild(tdActions);
+
+            keyListBody.appendChild(tr);
+        });
+    }
+
+    function showDeleteConfirm(prefix) {
+        pendingDeletePrefix = prefix;
+        deletePrefix.textContent = prefix;
+        deleteOverlay.classList.remove('hidden');
+    }
+
+    function hideDeleteConfirm() {
+        deleteOverlay.classList.add('hidden');
+        pendingDeletePrefix = '';
+    }
+
+    function deleteKey(prefix) {
+        // Strip trailing ellipsis to get the raw prefix for the API
+        var rawPrefix = prefix.replace(/\.{3}$/, '');
+        fetch(apiKeyUrl, {
+            method: 'DELETE',
+            headers: withCsrfHeaders({ 'Content-Type': 'application/json', 'Accept': 'application/json' }),
+            credentials: 'same-origin',
+            body: JSON.stringify({ key: rawPrefix })
+        })
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                hideDeleteConfirm();
+                loadKeys();
+            })
+            .catch(function () {
+                hideDeleteConfirm();
+                alert('Fehler beim Löschen des Schlüssels.');
+            });
+    }
+
+    function createKey(evt) {
+        evt.preventDefault();
+        var comment = commentInput.value.trim();
+        var minLen = parseInt(commentInput.getAttribute('minlength') || '1', 10);
+        var maxLen = parseInt(commentInput.getAttribute('maxlength') || '9999', 10);
+        if (comment.length < minLen || comment.length > maxLen) {
+            commentInput.focus();
+            return;
+        }
+        createBtn.disabled = true;
+
+        var payload = { comment: comment, role: parseInt(roleSelect.value, 10) };
+
+        if (validUntilInput.value) {
+            payload.valid_until = new Date(validUntilInput.value).toISOString();
+        }
+
+        fetch(apiKeyUrl, {
+            method: 'POST',
+            headers: withCsrfHeaders({ 'Content-Type': 'application/json', 'Accept': 'application/json' }),
+            credentials: 'same-origin',
+            body: JSON.stringify(payload)
+        })
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (data) {
+                createBtn.disabled = false;
+                commentInput.value = '';
+                validUntilInput.value = '';
+
+                // Show the new key value
+                newKeyValue.textContent = data.key;
+                newKeyBanner.classList.remove('hidden');
+
+                loadKeys();
+            })
+            .catch(function () {
+                createBtn.disabled = false;
+                alert('Fehler beim Erstellen des Schlüssels.');
+            });
+    }
+
+    function copyKey() {
+        var key = newKeyValue.textContent;
+        copyTextToClipboard(key)
+            .then(function () { showToast('Schlüssel kopiert'); })
+            .catch(function () { showToast('Fehler beim Kopieren', 'error'); });
+    }
+
+    // Event listeners
+    form.addEventListener('submit', createKey);
+    copyKeyBtn.addEventListener('click', copyKey);
+    deleteYes.addEventListener('click', function () { deleteKey(pendingDeletePrefix); });
+    deleteNo.addEventListener('click', hideDeleteConfirm);
+    deleteOverlay.addEventListener('click', function (e) {
+        if (e.target === deleteOverlay) hideDeleteConfirm();
+    });
+
+    // Initial load
+    loadKeys();
+})();

--- a/app/static/js/api-keys.js
+++ b/app/static/js/api-keys.js
@@ -243,7 +243,7 @@
             })
             .catch(function () {
                 createBtn.disabled = false;
-                alert('Fehler beim Erstellen des Schlüssels.');
+                showToast('Fehler beim Erstellen des Schlüssels.', 'error');
             });
     }
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -18,27 +18,6 @@ const API_PUSH_SUBSCRIBE_URL = _cfg.pushSubscribeUrl;
 const API_PUSH_UNSUBSCRIBE_URL = _cfg.pushUnsubscribeUrl;
 const API_PUSH_TOPICS_URL = _cfg.pushTopicsUrl;
 
-async function copyTextToClipboard(text) {
-    if (navigator.clipboard && window.isSecureContext) {
-        await navigator.clipboard.writeText(text);
-        return;
-    }
-
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    textArea.className = 'clipboard-textarea';
-    document.body.appendChild(textArea);
-    textArea.focus();
-    textArea.select();
-
-    const successful = document.execCommand('copy');
-    document.body.removeChild(textArea);
-
-    if (!successful) {
-        throw new Error('Copy command failed');
-    }
-}
-
 async function updateStatus() {
     try {
         let forDate = getForDateFromUrl();

--- a/app/static/js/clipboard.js
+++ b/app/static/js/clipboard.js
@@ -1,0 +1,20 @@
+async function copyTextToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    textArea.className = 'clipboard-textarea';
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    const successful = document.execCommand('copy');
+    document.body.removeChild(textArea);
+
+    if (!successful) {
+        throw new Error('Copy command failed');
+    }
+}

--- a/app/templates/_floating_btn_group.html
+++ b/app/templates/_floating_btn_group.html
@@ -1,5 +1,6 @@
 {% set _grp_visible = (show_preview_controls | default(false)) or (show_auth_button | default(false)) or
-(show_notification_create_btn | default(false)) or (show_preview_btn | default(false)) or show_back_btn %}
+(show_notification_create_btn | default(false)) or (show_api_keys_btn | default(false)) or (show_preview_btn |
+default(false)) or show_back_btn %}
 <div id="floating-btn-group" class="{{ 'visible' if _grp_visible else '' }}">
     {% if show_preview_controls | default(false) %}
     {% include "_preview_controls.html" %}
@@ -20,6 +21,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 5v14M5 12h14" />
+        </svg>
+    </a>
+    {% endif %}
+    {% if show_api_keys_btn | default(false) %}
+    <a href="{{ url_api_keys }}" class="floating-btn" title="API-Schlüssel verwalten"
+        data-tooltip="API-Schlüssel verwalten">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path
+                d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
         </svg>
     </a>
     {% endif %}

--- a/app/templates/api-keys.html
+++ b/app/templates/api-keys.html
@@ -1,30 +1,31 @@
 {% extends "base.html" %}
 
 {% block head_meta %}
-    <meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="noindex, nofollow">
 {% endblock %}
 
 {% block title %}Fribbe - API-Schlüssel verwalten{% endblock %}
 
 {% block head_styles %}
-    <link rel="stylesheet" href="/static/css/api-keys.styles.css?v={{ content_hash_version }}">
+<link rel="stylesheet" href="/static/css/api-keys.styles.css?v={{ content_hash_version }}">
 {% endblock %}
 
-{% block body_attrs %} data-url-api-keys="{{ url_api_internal_api_keys }}" data-url-api-key="{{ url_api_internal_api_key }}" data-role-labels='{{ role_labels | tojson }}'{% endblock %}
+{% block body_attrs %} data-url-api-keys="{{ url_api_internal_api_keys }}" data-url-api-key="{{ url_api_internal_api_key
+}}" data-role-label-admin="{{ admin_role_label }}" data-role-labels='{{ role_labels | tojson }}'{% endblock %}
 
 {% block content %}
-    <div class="container">
-        {% include "_theme_toggle.html" %}
-        <h1>API-Schlüssel verwalten</h1>
-        <p class="subtitle">Erstelle und verwalte API-Schlüssel für den Zugriff auf die Anwendung.</p>
+<div class="container">
+    {% include "_theme_toggle.html" %}
+    <h1>API-Schlüssel verwalten</h1>
+    <p class="subtitle">Erstelle und verwalte API-Schlüssel für den Zugriff auf die Anwendung.</p>
 
-        <section id="create-key-section" class="card">
-            <h2>Neuen Schlüssel erstellen</h2>
-            <form id="create-key-form" novalidate>
-                <div class="form-group">
-                    <label for="key-comment">Kommentar</label>
-                    <input type="text" id="key-comment" name="comment" placeholder="z.B. Mein Gerät"
-                        autocomplete="off" required minlength="{{ comment_min_length }}" maxlength="{{ comment_max_length }}">
+    <section id="create-key-section" class="card">
+        <h2>Neuen Schlüssel erstellen</h2>
+        <form id="create-key-form" novalidate>
+            <div class="form-group">
+                <label for="key-comment">Kommentar</label>
+                <input type="text" id="key-comment" name="comment" placeholder="z.B. Mein Gerät" autocomplete="off" required
+                    minlength="{{ comment_min_length }}" maxlength="{{ comment_max_length }}">
                 </div>
                 <div class="form-row">
                     <div class="form-group">
@@ -42,59 +43,59 @@
                     </div>
                 </div>
                 <button type="submit" id="create-key-btn" class="primary">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M12 5v14M5 12h14" />
                     </svg>
                     Schlüssel erstellen
                 </button>
-            </form>
-        </section>
+                </form>
+                </section>
 
-        <div id="new-key-banner" class="new-key-banner hidden" role="alert">
-            <p class="new-key-label">Neuer Schlüssel (nur jetzt sichtbar):</p>
-            <div class="new-key-value-row">
-                <code id="new-key-value"></code>
-                <button id="copy-key-btn" type="button" class="copy-btn" title="Kopieren">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-
-        <section id="key-list-section" class="card">
-            <h2>Vorhandene Schlüssel</h2>
-            <div id="key-list-loading" class="loading-hint">Lade Schlüssel...</div>
-            <div id="key-list-empty" class="empty-hint hidden">Keine API-Schlüssel vorhanden.</div>
-            <table id="key-list-table" class="key-table hidden">
-                <thead>
-                    <tr>
-                        <th>Präfix</th>
-                        <th>Kommentar</th>
-                        <th>Rolle</th>
-                        <th>Gültig bis</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody id="key-list-body"></tbody>
-            </table>
-        </section>
-    </div>
-
-    <div id="delete-confirm-overlay" class="confirm-overlay hidden">
-        <div class="confirm-dialog">
-            <p>Schlüssel <strong id="delete-confirm-prefix"></strong> wirklich löschen?</p>
-            <div class="actions">
-                <button id="delete-confirm-yes" class="primary danger" type="button">Löschen</button>
-                <button id="delete-confirm-no" class="secondary" type="button">Abbrechen</button>
-            </div>
+    <div id="new-key-banner" class="new-key-banner hidden" role="alert">
+        <p class="new-key-label">Neuer Schlüssel (nur jetzt sichtbar):</p>
+        <div class="new-key-value-row">
+            <code id="new-key-value"></code>
+            <button id="copy-key-btn" type="button" class="copy-btn" title="Kopieren">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+            </button>
         </div>
     </div>
+
+    <section id="key-list-section" class="card">
+        <h2>Vorhandene Schlüssel</h2>
+        <div id="key-list-loading" class="loading-hint">Lade Schlüssel...</div>
+        <div id="key-list-empty" class="empty-hint hidden">Keine API-Schlüssel vorhanden.</div>
+        <table id="key-list-table" class="key-table hidden">
+            <thead>
+                <tr>
+                    <th>Präfix</th>
+                    <th>Kommentar</th>
+                    <th data-sort="role" class="sortable" aria-sort="none">Rolle</th>
+                    <th data-sort="valid_until" class="sortable" aria-sort="none">Gültig bis</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody id="key-list-body"></tbody>
+        </table>
+    </section>
+    </div>
+
+<div id="delete-confirm-overlay" class="confirm-overlay hidden">
+    <div class="confirm-dialog">
+        <p>Schlüssel <strong id="delete-confirm-prefix"></strong> wirklich löschen?</p>
+        <div class="actions">
+            <button id="delete-confirm-yes" class="primary danger" type="button">Löschen</button>
+            <button id="delete-confirm-no" class="secondary" type="button">Abbrechen</button>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
-    <script src="/static/js/api-keys.js?v={{ content_hash_version }}"></script>
+<script src="/static/js/api-keys.js?v={{ content_hash_version }}"></script>
 {% endblock %}

--- a/app/templates/api-keys.html
+++ b/app/templates/api-keys.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+
+{% block head_meta %}
+    <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block title %}Fribbe - API-Schlüssel verwalten{% endblock %}
+
+{% block head_styles %}
+    <link rel="stylesheet" href="/static/css/api-keys.styles.css?v={{ content_hash_version }}">
+{% endblock %}
+
+{% block body_attrs %} data-url-api-keys="{{ url_api_internal_api_keys }}" data-url-api-key="{{ url_api_internal_api_key }}" data-role-labels='{{ role_labels | tojson }}'{% endblock %}
+
+{% block content %}
+    <div class="container">
+        {% include "_theme_toggle.html" %}
+        <h1>API-Schlüssel verwalten</h1>
+        <p class="subtitle">Erstelle und verwalte API-Schlüssel für den Zugriff auf die Anwendung.</p>
+
+        <section id="create-key-section" class="card">
+            <h2>Neuen Schlüssel erstellen</h2>
+            <form id="create-key-form" novalidate>
+                <div class="form-group">
+                    <label for="key-comment">Kommentar</label>
+                    <input type="text" id="key-comment" name="comment" placeholder="z.B. Mein Gerät"
+                        autocomplete="off" required minlength="{{ comment_min_length }}" maxlength="{{ comment_max_length }}">
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="key-role">Rolle</label>
+                        <select id="key-role" name="role">
+                            {% for role in roles %}
+                            <option value="{{ role.value }}">{{ role.label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="key-valid-until">Gültig bis (optional)</label>
+                        <input type="datetime-local" id="key-valid-until" name="valid_until">
+                        <small class="field-hint">Standard: {{ default_validity_days }} Tage ab Erstellung</small>
+                    </div>
+                </div>
+                <button type="submit" id="create-key-btn" class="primary">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M12 5v14M5 12h14" />
+                    </svg>
+                    Schlüssel erstellen
+                </button>
+            </form>
+        </section>
+
+        <div id="new-key-banner" class="new-key-banner hidden" role="alert">
+            <p class="new-key-label">Neuer Schlüssel (nur jetzt sichtbar):</p>
+            <div class="new-key-value-row">
+                <code id="new-key-value"></code>
+                <button id="copy-key-btn" type="button" class="copy-btn" title="Kopieren">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        <section id="key-list-section" class="card">
+            <h2>Vorhandene Schlüssel</h2>
+            <div id="key-list-loading" class="loading-hint">Lade Schlüssel...</div>
+            <div id="key-list-empty" class="empty-hint hidden">Keine API-Schlüssel vorhanden.</div>
+            <table id="key-list-table" class="key-table hidden">
+                <thead>
+                    <tr>
+                        <th>Präfix</th>
+                        <th>Kommentar</th>
+                        <th>Rolle</th>
+                        <th>Gültig bis</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="key-list-body"></tbody>
+            </table>
+        </section>
+    </div>
+
+    <div id="delete-confirm-overlay" class="confirm-overlay hidden">
+        <div class="confirm-dialog">
+            <p>Schlüssel <strong id="delete-confirm-prefix"></strong> wirklich löschen?</p>
+            <div class="actions">
+                <button id="delete-confirm-yes" class="primary danger" type="button">Löschen</button>
+                <button id="delete-confirm-no" class="secondary" type="button">Abbrechen</button>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+    <script src="/static/js/api-keys.js?v={{ content_hash_version }}"></script>
+{% endblock %}

--- a/app/templates/api-keys.html
+++ b/app/templates/api-keys.html
@@ -56,7 +56,7 @@
         <p class="new-key-label">Neuer Schlüssel (nur jetzt sichtbar):</p>
         <div class="new-key-value-row">
             <code id="new-key-value"></code>
-            <button id="copy-key-btn" type="button" class="copy-btn" title="Kopieren">
+            <button id="copy-key-btn" type="button" class="copy-btn" title="Kopieren" aria-label="Kopieren">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />

--- a/app/templates/api-keys.html
+++ b/app/templates/api-keys.html
@@ -10,8 +10,7 @@
 <link rel="stylesheet" href="/static/css/api-keys.styles.css?v={{ content_hash_version }}">
 {% endblock %}
 
-{% block body_attrs %} data-url-api-keys="{{ url_api_internal_api_keys }}" data-url-api-key="{{ url_api_internal_api_key
-}}" data-role-label-admin="{{ admin_role_label }}" data-role-labels='{{ role_labels | tojson }}'{% endblock %}
+{% block body_attrs %} data-url-api-keys="{{ url_api_internal_api_keys }}" data-url-api-key="{{ url_api_internal_api_key }}" data-role-label-admin="{{ admin_role_label }}" data-role-labels='{{ role_labels | tojson }}'{% endblock %}
 
 {% block content %}
 <div class="container">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
     {% block head_meta %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/shared.css?v={{ content_hash_version }}">
+    <link rel="stylesheet" href="/static/css/base.css?v={{ content_hash_version }}">
     {% block head_styles %}{% endblock %}
     <!-- Prevent flash of unstyled content when dark mode is active -->
     <script>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,6 +27,7 @@
         aria-live="polite" data-timeout="{{ toast_display_ms }}">{{ flash_message }}</div>
     <script src="/static/js/csrf.js?v={{ content_hash_version }}"></script>
     <script src="/static/js/toast.js?v={{ content_hash_version }}"></script>
+    <script src="/static/js/clipboard.js?v={{ content_hash_version }}"></script>
     <script src="/static/js/theme.js?v={{ content_hash_version }}"></script>
     {% block scripts %}{% endblock %}
     </body>

--- a/tests/access_role_tests.py
+++ b/tests/access_role_tests.py
@@ -88,7 +88,7 @@ def test_api_key_to_dict_includes_role() -> None:
         role=AccessRole.NOTIFICATION_OPERATOR,
     )
     d = key.to_dict()
-    assert d["role"] == "notification_operator"
+    assert d["role"] == "200"
 
 
 def test_api_key_from_dict_parses_role() -> None:
@@ -96,10 +96,22 @@ def test_api_key_from_dict_parses_role() -> None:
         "key": "A" * env.MIN_TOKEN_LENGTH,
         "comment": "",
         "valid_until": "2030-01-01T00:00:00+00:00",
-        "role": "reader",
+        "role": "100",
     }
     key = ApiKey.from_dict(d)
     assert key.role == AccessRole.READER
+
+
+def test_api_key_from_dict_parses_legacy_role_name() -> None:
+    """Keys stored with the old name-based format must still deserialize correctly."""
+    d = {
+        "key": "A" * env.MIN_TOKEN_LENGTH,
+        "comment": "",
+        "valid_until": "2030-01-01T00:00:00+00:00",
+        "role": "notification_operator",
+    }
+    key = ApiKey.from_dict(d)
+    assert key.role == AccessRole.NOTIFICATION_OPERATOR
 
 
 def test_api_key_from_dict_missing_role_defaults_to_reader() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,17 @@ individual tests can inject mocks cleanly via ``app.dependency_overrides``.
 """
 
 from collections.abc import Generator
+from urllib.parse import quote
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse
 from fastapi.testclient import TestClient
 from starsessions import InMemoryStore, SessionAutoloadMiddleware, SessionMiddleware
 
 from app import env
+from app.api.hybrid_auth import AuthRedirectError
+from app.api.requests import AuthRedirectQuery
 from app.csrf import FormFieldCSRFMiddleware
 from app.routers import api_keys, auth, internal, misc, notification_ui, notifications, pages, push, status, wardens
 
@@ -51,6 +55,13 @@ def test_app() -> FastAPI:
     test_app.include_router(notification_ui.router)
     test_app.include_router(wardens.router)
     test_app.include_router(pages.router)
+
+    async def _handle_auth_redirect(_request: Request, exc: AuthRedirectError) -> RedirectResponse:
+        safe_next = AuthRedirectQuery.sanitize_url(exc.next_url) or "/"
+        return RedirectResponse(url=f"/auth?next={quote(safe_next, safe='/:?=&')}", status_code=302)
+
+    test_app.add_exception_handler(AuthRedirectError, _handle_auth_redirect)  # type: ignore[arg-type]
+
     return test_app
 
 

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -1183,3 +1183,287 @@ def test_notifications_put_returns_404_when_not_found(
     )
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /api-keys page
+# ---------------------------------------------------------------------------
+
+
+def test_api_keys_page_redirects_to_auth_when_not_signed_in(client: TestClient) -> None:
+    """Unauthenticated access to /api-keys must redirect to /auth."""
+    response = client.get("/api-keys", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert "/auth" in response.headers["location"]
+
+
+def test_api_keys_page_returns_403_for_reader_role(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """READER role is below ADMIN — /api-keys must return 403."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    api_key = ApiKey.generate_new(
+        comment="test-reader",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.READER,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": api_key.key, "next": "/"})
+
+    response = client.get("/api-keys")
+
+    assert response.status_code == 403
+
+
+def test_api_keys_page_returns_403_for_operator_role(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """NOTIFICATION_OPERATOR role is below ADMIN — /api-keys must return 403."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    api_key = ApiKey.generate_new(
+        comment="test-operator",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.NOTIFICATION_OPERATOR,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": api_key.key, "next": "/"})
+
+    response = client.get("/api-keys")
+
+    assert response.status_code == 403
+
+
+def test_api_keys_page_renders_for_admin(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADMIN role must be able to access /api-keys."""
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.get("/api-keys")
+
+    assert response.status_code == 200
+    assert "API-Schlüssel verwalten" in response.text
+    assert 'id="create-key-form"' in response.text
+    assert 'id="key-list-table"' in response.text
+    assert f'value="{AccessRole.READER.value}"' in response.text  # role options populated from AccessRole
+    assert "data-role-labels" in response.text
+
+
+def test_index_shows_api_keys_btn_for_admin(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admin users should see the API keys floating button on the index page."""
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "is_login_button_enabled", lambda: True)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert 'href="/api-keys"' in response.text
+
+
+def test_index_hides_api_keys_btn_for_operator(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Operator-role users should not see the API keys button."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    api_key = ApiKey.generate_new(
+        comment="test-operator",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.NOTIFICATION_OPERATOR,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": api_key.key, "next": "/"})
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert 'href="/api-keys"' not in response.text
+
+
+def test_index_hides_api_keys_btn_when_not_signed_in(client: TestClient) -> None:
+    """Unauthenticated visitors must not see the API keys button."""
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert 'href="/api-keys"' not in response.text
+
+
+def test_api_keys_page_has_back_button(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The /api-keys page is a sub-page and should show a back button."""
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.get("/api-keys")
+
+    assert response.status_code == 200
+    assert 'title="Zurück"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# API key self-delete protection
+# ---------------------------------------------------------------------------
+
+
+def test_delete_own_api_key_returns_403(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An admin API key must not be allowed to delete itself."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    api_key = ApiKey.generate_new(
+        comment="self-key",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.ADMIN,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": api_key.key, "next": "/"})
+
+    response = client.request(
+        "DELETE",
+        "/api/internal/api_key",
+        json={"key": api_key.key[:5]},
+        headers=_get_csrf_headers(client),
+    )
+
+    assert response.status_code == 403
+    assert "own" in response.json()["detail"].lower()
+
+
+def test_admin_token_can_delete_any_api_key(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ADMIN_TOKEN users are not API keys themselves and can delete any key."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    api_key = ApiKey.generate_new(
+        comment="deletable",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.ADMIN,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.request(
+        "DELETE",
+        "/api/internal/api_key",
+        json={"key": api_key.key[:5]},
+        headers=_get_csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+
+
+def test_list_api_keys_includes_self_key_prefix(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The list endpoint must include self_key_prefix when authenticated with an API key."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    api_key = ApiKey.generate_new(
+        comment="self-key",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.ADMIN,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": api_key.key, "next": "/"})
+
+    response = client.get("/api/internal/api_keys")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["self_key_prefix"] is not None
+    assert body["self_key_prefix"] == api_key.key[:5] + "..."
+
+
+def test_list_api_keys_has_null_self_key_prefix_for_admin_token(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ADMIN_TOKEN sessions should have null self_key_prefix."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    api_key = ApiKey.generate_new(
+        comment="other-key",
+        valid_until=datetime(2030, 12, 31, tzinfo=_UTC),
+        role=AccessRole.ADMIN,
+    )
+    assert EphemeralAPIKeyStore.append(api_key)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.get("/api/internal/api_keys")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["self_key_prefix"] is None
+
+
+# ---------------------------------------------------------------------------
+# API key create validation
+# ---------------------------------------------------------------------------
+
+
+def test_create_api_key_rejects_empty_comment(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Creating a key without a comment must fail with 422."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.post(
+        "/api/internal/api_key",
+        json={"comment": ""},
+        headers=_get_csrf_headers(client),
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_api_key_rejects_oversized_comment(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Creating a key with a comment exceeding 200 characters must fail with 422."""
+    keys_path = tmp_path / "api_keys.json"
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(keys_path))
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+
+    response = client.post(
+        "/api/internal/api_key",
+        json={"comment": "x" * 201},
+        headers=_get_csrf_headers(client),
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
- Introduced a new route for managing API keys at /api-keys.
- Implemented frontend components for creating and listing API keys.
- Added styles for the API keys page.
- Created JavaScript functionality for handling API key creation, deletion, and copying to clipboard.
- Updated navigation context to show/hide API keys button based on user role.
- Added tests for API key access control and validation.
- Refactored clipboard functionality into a separate module.