### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fribbe-status-checker"
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">=3.12"
 dependencies = [
     "huawei-lte-api>=1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ wheels = [
 
 [[package]]
 name = "fribbe-status-checker"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.5.1

### Changes since last release

```
a95c2f3 chore(release): v0.5.1
05322c2 chore: update lock file and licenses for v0.5.1
7584c1f feat: add release management script and update dependencies
712962f feat: add commit message generation instructions for GitHub Copilot
e4552eb style: update linting rules and clean up print statements in scripts
04a9d57 fix: update api key role default from admin to reader in test
372995a feat: add API key management page and functionality (#73)
```

Merging to `main` will trigger the CI/CD pipeline and create a stable GitHub release tagged `v0.5.1`.
