### PR TITLE
chore(release): v0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fribbe-status-checker"
-version = "0.5.1"
+version = "0.5.2"
 requires-python = ">=3.12"
 dependencies = [
     "huawei-lte-api>=1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ wheels = [
 
 [[package]]
 name = "fribbe-status-checker"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.5.2

### Changes since last release

```
57e578c chore(release): v0.5.2
e538f83 chore: update lock file and licenses for v0.5.2
76bd577 ci: add nightly tag for non-new version images in CI/CD workflow
16dcf02 fix: update image tag computation in CI/CD workflow
94d58eb fix: update username reference in changelog template
9c624f2 fix: update nightly release process in CI/CD pipeline
```

Merging to `main` will trigger the CI/CD pipeline and create a stable GitHub release tagged `v0.5.2`.
