### PR TITLE
test: improve coverage and test isolation; enforce 80% in CI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ For larger frontend changes, validate against `http://localhost:8007`.
 .github/
   copilot-instructions.md  # Instructions for Copilot
   workflows/
-    ci-cd.yml              # CI/CD pipeline (lint, test, build, deploy)
+    ci-cd.yml              # CI/CD pipeline (lint, test, build, deploy, coverage enforcement)
     codeql.yml             # CodeQL security analysis
   dependabot.yml           # Dependabot config for dependency updates
 app/
@@ -65,6 +65,7 @@ README.md                  # Project overview, setup, conventions, instructions
 - **Linting**: Line length 120. Ruff rules: `ALL`. Tests rules differ. See `pyproject.toml` for details.
 - **Markdown linting**: `markdownlint-cli2` enforced in CI (warnings as errors). Config in `.markdownlint-cli2.yaml`. Run locally with `npx markdownlint-cli2`.
 - **Licenses**: After adding or removing any dependency in `pyproject.toml`, run `uv run generate-licenses` and commit the updated `app/licenses.json`. The CI lint job fails if this file is out of date.
+- **Coverage**: CI enforces ≥80% overall test coverage (`--cov-fail-under=80`). On PRs, `diff-cover` requires ≥80% coverage on new/changed lines (`diff-cover coverage.xml --compare-branch=origin/main --fail-under=80`).
 
 ## Copilot Instructions
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,8 +57,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -70,7 +75,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-groups
       - name: Test with pytest
-        run: uv run pytest tests/ --junitxml=junit/test-results.xml --cov=app --cov-report=xml --cov-report=html
+        run: uv run pytest tests/ --junitxml=junit/test-results.xml --cov=app --cov-report=xml --cov-report=html --cov-fail-under=80
+      - name: Diff-cover
+        if: github.event_name == 'pull_request'
+        run: uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
+      - name: Coverage report
+        if: github.event_name == 'pull_request' && !cancelled()
+        uses: MishaKav/pytest-coverage-comment@v1
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: junit/test-results.xml
 
   build-and-push:
     needs: [lint, test]

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ node_modules/
 # Test files
 dev-data/
 test-data/
+coverage.json

--- a/app/routers/internal.py
+++ b/app/routers/internal.py
@@ -45,7 +45,7 @@ def details(
 async def config(request: ConfigRequest, _: Annotated[str, Depends(HybridAuth(min_role=AccessRole.ADMIN))]) -> Response:
     """Update presence detection thresholds."""
     if not any((request.threshold_min_non_empty_ct, request.threshold_min_many_ct)):
-        return Response(status_code=304)  # ^= Not Modified
+        return Response(status_code=204)
 
     thresholds = PresenceThresholds()
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -77,7 +77,7 @@ data-push-topics-url="{{ url_api_push_topics }}"{% endblock %}
     <div id="bootstrap-banner" class="bootstrap-banner{% if not (setup_banner | default(false)) %} hidden{% endif %}"
         role="alert" aria-live="polite" aria-atomic="true">
         <strong>⚠ No admin access configured.</strong> Set the <code>ADMIN_TOKEN</code> environment variable and
-        redeploy to secure the admin interface.
+        redeploy to enable or regain admin access and manage API keys.
     </div>
     <div class="container">
         {% include "_theme_toggle.html" %}

--- a/cliff.toml
+++ b/cliff.toml
@@ -19,7 +19,10 @@ body = """
       ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
       {%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}
   {%- endfor %}
-{% endfor %}\n
+{% endfor %}
+{%- if previous.version %}\n
+**Full Changelog**: [{{ previous.version }}...{{ version }}]({{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }})\n
+{%- endif %}\n
 """
 footer = ""
 trim = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest-dotenv>=0.5.2",
     "pip-licenses>=5.5.5",
     "python-dotenv>=1.0.0",
+    "diff-cover>=9.6.0",
 ]
 
 [tool.pytest.ini_options]
@@ -49,6 +50,10 @@ env_override_existing_values = true
 filterwarnings = [
     "error" # turn all warnings into errors
 ]
+
+[tool.coverage.run]
+source = ["app"]
+omit = ["tests/*", "scripts/*"]
 
 [tool.ruff]
 line-length = 120

--- a/tests/access_role_tests.py
+++ b/tests/access_role_tests.py
@@ -373,7 +373,7 @@ def test_admin_token_accesses_admin_endpoint(
         json={},
         headers={"api_key": TEST_ADMIN_TOKEN},
     )
-    assert response.status_code == 304  # not modified (no thresholds set), but not 403
+    assert response.status_code == 204  # no content
 
 
 def test_admin_api_key_can_access_admin_endpoints(

--- a/tests/env_tests.py
+++ b/tests/env_tests.py
@@ -146,75 +146,107 @@ def test_validate_raises_when_session_secret_key_too_short(
         env.validate()
 
 
-def test_feature_presence_true_when_all_router_creds_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ROUTER_IP", "192.168.1.1")
-    monkeypatch.setenv("ROUTER_USERNAME", "admin")
-    monkeypatch.setenv("ROUTER_PASSWORD", "secret")
+# ---------------------------------------------------------------------------
+# Feature flag checks — parametrized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("set_vars", "del_vars", "feature_fn", "expected"),
+    [
+        # presence
+        (
+            {"ROUTER_IP": "192.168.1.1", "ROUTER_USERNAME": "admin", "ROUTER_PASSWORD": "secret"},
+            [],
+            env.is_presence_enabled,
+            True,
+        ),
+        (
+            {"ROUTER_IP": "192.168.1.1"},
+            ["ROUTER_USERNAME", "ROUTER_PASSWORD"],
+            env.is_presence_enabled,
+            False,
+        ),
+        # push
+        (
+            {
+                "VAPID_PRIVATE_KEY": "private",
+                "VAPID_PUBLIC_KEY": "public",
+                "VAPID_CLAIM_SUBJECT": "https://example.com",
+            },
+            [],
+            env.is_push_enabled,
+            True,
+        ),
+        (
+            {"VAPID_PRIVATE_KEY": "private"},
+            ["VAPID_PUBLIC_KEY", "VAPID_CLAIM_SUBJECT"],
+            env.is_push_enabled,
+            False,
+        ),
+        # weather
+        (
+            {"OPENWEATHERMAP_API_KEY": "apikey", "WEATHER_LAT": "48.3", "WEATHER_LON": "10.9"},
+            [],
+            env.is_weather_enabled,
+            True,
+        ),
+        (
+            {"OPENWEATHERMAP_API_KEY": "apikey"},
+            ["WEATHER_LAT", "WEATHER_LON"],
+            env.is_weather_enabled,
+            False,
+        ),
+        # legal page
+        (
+            {"OPERATOR_NAME": "Max Mustermann", "OPERATOR_EMAIL": "max@example.com"},
+            [],
+            env.is_legal_page_enabled,
+            True,
+        ),
+        (
+            {"OPERATOR_NAME": "Max Mustermann"},
+            ["OPERATOR_EMAIL"],
+            env.is_legal_page_enabled,
+            False,
+        ),
+        # login button
+        (
+            {"SHOW_AUTH_BUTTON": "true"},
+            [],
+            env.is_login_button_enabled,
+            True,
+        ),
+        (
+            {},
+            ["SHOW_AUTH_BUTTON"],
+            env.is_login_button_enabled,
+            False,
+        ),
+    ],
+    ids=[
+        "presence-enabled",
+        "presence-disabled",
+        "push-enabled",
+        "push-disabled",
+        "weather-enabled",
+        "weather-disabled",
+        "legal-enabled",
+        "legal-disabled",
+        "login-button-enabled",
+        "login-button-disabled",
+    ],
+)
+def test_feature_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    set_vars: dict[str, str],
+    del_vars: list[str],
+    feature_fn: object,
+    expected: bool,  # noqa: FBT001
+) -> None:
+    for k, v in set_vars.items():
+        monkeypatch.setenv(k, v)
+    for k in del_vars:
+        monkeypatch.delenv(k, raising=False)
     env.load()
-    assert env.is_presence_enabled() is True
-
-
-def test_feature_presence_false_when_any_router_cred_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ROUTER_IP", "192.168.1.1")
-    monkeypatch.delenv("ROUTER_USERNAME", raising=False)
-    monkeypatch.delenv("ROUTER_PASSWORD", raising=False)
-    env.load()
-    assert env.is_presence_enabled() is False
-
-
-def test_feature_push_true_when_all_vapid_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("VAPID_PRIVATE_KEY", "private")
-    monkeypatch.setenv("VAPID_PUBLIC_KEY", "public")
-    monkeypatch.setenv("VAPID_CLAIM_SUBJECT", "https://example.com")
-    env.load()
-    assert env.is_push_enabled() is True
-
-
-def test_feature_push_false_when_any_vapid_var_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("VAPID_PRIVATE_KEY", "private")
-    monkeypatch.delenv("VAPID_PUBLIC_KEY", raising=False)
-    monkeypatch.delenv("VAPID_CLAIM_SUBJECT", raising=False)
-    env.load()
-    assert env.is_push_enabled() is False
-
-
-def test_feature_weather_true_when_all_owm_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "apikey")
-    monkeypatch.setenv("WEATHER_LAT", "48.3")
-    monkeypatch.setenv("WEATHER_LON", "10.9")
-    env.load()
-    assert env.is_weather_enabled() is True
-
-
-def test_feature_weather_false_when_any_owm_var_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "apikey")
-    monkeypatch.delenv("WEATHER_LAT", raising=False)
-    monkeypatch.delenv("WEATHER_LON", raising=False)
-    env.load()
-    assert env.is_weather_enabled() is False
-
-
-def test_feature_legal_page_true_when_both_operator_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.setenv("OPERATOR_EMAIL", "max@example.com")
-    env.load()
-    assert env.is_legal_page_enabled() is True
-
-
-def test_feature_legal_page_false_when_any_operator_var_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.delenv("OPERATOR_EMAIL", raising=False)
-    env.load()
-    assert env.is_legal_page_enabled() is False
-
-
-def test_feature_login_button_true_when_show_auth_button_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SHOW_AUTH_BUTTON", "true")
-    env.load()
-    assert env.is_login_button_enabled() is True
-
-
-def test_feature_login_button_false_when_show_auth_button_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("SHOW_AUTH_BUTTON", raising=False)
-    env.load()
-    assert env.is_login_button_enabled() is False
+    assert feature_fn() is expected  # type: ignore[operator]

--- a/tests/env_tests.py
+++ b/tests/env_tests.py
@@ -1,5 +1,6 @@
 """Tests for app.env load() / validate()."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -241,7 +242,7 @@ def test_feature_flags(
     monkeypatch: pytest.MonkeyPatch,
     set_vars: dict[str, str],
     del_vars: list[str],
-    feature_fn: object,
+    feature_fn: Callable[[], bool],
     expected: bool,  # noqa: FBT001
 ) -> None:
     for k, v in set_vars.items():
@@ -249,4 +250,4 @@ def test_feature_flags(
     for k in del_vars:
         monkeypatch.delenv(k, raising=False)
     env.load()
-    assert feature_fn() is expected  # type: ignore[operator]
+    assert feature_fn() is expected

--- a/tests/ephemeral_api_key_store_tests.py
+++ b/tests/ephemeral_api_key_store_tests.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from app import env
+from app.api.access_role import AccessRole
 from app.api.ephemeral_api_key_store import EphemeralAPIKeyStore, RemoveResult
 from app.api.responses import ApiKey
 
@@ -159,3 +160,43 @@ def test_remove_returns_ambiguous_when_multiple_matches() -> None:
 
     assert EphemeralAPIKeyStore.remove(shared_prefix) == RemoveResult.AMBIGUOUS
     assert len(EphemeralAPIKeyStore.load()) == 2
+
+
+# ---------------------------------------------------------------------------
+# has_valid_admin_key
+# ---------------------------------------------------------------------------
+
+
+def test_has_valid_admin_key_empty_store() -> None:
+    EphemeralAPIKeyStore.save([])
+    assert EphemeralAPIKeyStore.has_valid_admin_key() is False
+
+
+def test_has_valid_admin_key_non_admin_role() -> None:
+    key = ApiKey.generate_new(
+        comment="reader",
+        valid_until=datetime.now(tz=ZoneInfo("Europe/Berlin")) + timedelta(days=1),
+        role=AccessRole.READER,
+    )
+    EphemeralAPIKeyStore.save([key])
+    assert EphemeralAPIKeyStore.has_valid_admin_key() is False
+
+
+def test_has_valid_admin_key_expired_admin() -> None:
+    key = ApiKey.generate_new(
+        comment="expired admin",
+        valid_until=datetime.now(tz=ZoneInfo("Europe/Berlin")) - timedelta(days=1),
+        role=AccessRole.ADMIN,
+    )
+    EphemeralAPIKeyStore.save([key])
+    assert EphemeralAPIKeyStore.has_valid_admin_key() is False
+
+
+def test_has_valid_admin_key_valid_admin() -> None:
+    key = ApiKey.generate_new(
+        comment="valid admin",
+        valid_until=datetime.now(tz=ZoneInfo("Europe/Berlin")) + timedelta(days=1),
+        role=AccessRole.ADMIN,
+    )
+    EphemeralAPIKeyStore.save([key])
+    assert EphemeralAPIKeyStore.has_valid_admin_key() is True

--- a/tests/message_service_tests.py
+++ b/tests/message_service_tests.py
@@ -1,0 +1,54 @@
+"""Tests for MessageService.get_season and get_daytime helpers."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.message_service import MessageService
+
+_TZ = ZoneInfo("Europe/Berlin")
+
+
+@pytest.mark.parametrize(
+    ("month", "expected_season"),
+    [
+        (1, "winter"),
+        (2, "winter"),
+        (3, "spring"),
+        (4, "spring"),
+        (5, "spring"),
+        (6, "summer"),
+        (7, "summer"),
+        (8, "summer"),
+        (9, "autumn"),
+        (10, "autumn"),
+        (11, "autumn"),
+        (12, "winter"),
+    ],
+)
+def test_get_season(month: int, expected_season: str) -> None:
+    svc = MessageService()
+    dt = datetime(2026, month, 15, 12, 0, tzinfo=_TZ)
+    assert svc.get_season(dt) == expected_season
+
+
+@pytest.mark.parametrize(
+    ("hour", "expected_daytime"),
+    [
+        (0, "night"),
+        (4, "night"),
+        (5, "morning"),
+        (9, "morning"),
+        (10, "day"),
+        (15, "day"),
+        (16, "evening"),
+        (21, "evening"),
+        (22, "night"),
+        (23, "night"),
+    ],
+)
+def test_get_daytime(hour: int, expected_daytime: str) -> None:
+    svc = MessageService()
+    dt = datetime(2026, 6, 15, hour, 0, tzinfo=_TZ)
+    assert svc.get_daytime(dt) == expected_daytime

--- a/tests/notification_service_tests.py
+++ b/tests/notification_service_tests.py
@@ -188,3 +188,81 @@ async def test_poll_skips_when_no_push_sender(tmp_path: Path, monkeypatch: pytes
     svc.add("Test", None, None, enabled=True)
 
     await svc._check_newly_active_notifications()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# delete_many()
+# ---------------------------------------------------------------------------
+
+
+def test_delete_many_all_clears_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.api.requests import NotificationFilterId
+
+    svc = _make_service(tmp_path, monkeypatch)
+    svc.add("first", None, None, enabled=True)
+    svc.add("second", None, None, enabled=False)
+
+    count = svc.delete_many([NotificationFilterId.ALL])
+
+    assert count == 2
+    assert svc.list_all() == []
+
+
+def test_delete_many_all_active_deletes_only_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.api.requests import NotificationFilterId
+
+    svc = _make_service(tmp_path, monkeypatch)
+    svc.add("active msg", None, None, enabled=True)
+    svc.add("disabled msg", None, None, enabled=False)
+
+    count = svc.delete_many([NotificationFilterId.ALL_ACTIVE])
+
+    assert count == 1
+    remaining = svc.list_all()
+    assert len(remaining) == 1
+    assert remaining[0].message == "disabled msg"
+
+
+def test_delete_many_by_specific_nid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    svc = _make_service(tmp_path, monkeypatch)
+    svc.add("hello", None, None, enabled=True)
+    nid = svc.list_all()[0].id
+
+    count = svc.delete_many([nid])
+
+    assert count == 1
+    assert svc.list_all() == []
+
+
+def test_delete_many_nonexistent_nid_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    svc = _make_service(tmp_path, monkeypatch)
+
+    count = svc.delete_many(["nid-does-not-exist"])
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# _run_clean_old_notifications()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_clean_old_notifications_deletes_outdated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    svc = _make_service(tmp_path, monkeypatch)
+    past = _NOW - timedelta(days=2)
+    svc.add("outdated", None, past, enabled=True)
+
+    await svc._run_clean_old_notifications()
+
+    assert svc.list_all() == []
+
+
+@pytest.mark.asyncio
+async def test_run_clean_old_notifications_keeps_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    svc = _make_service(tmp_path, monkeypatch)
+    svc.add("still active", None, _FUTURE, enabled=True)
+
+    await svc._run_clean_old_notifications()
+
+    assert len(svc.list_all()) == 1

--- a/tests/page_utils_tests.py
+++ b/tests/page_utils_tests.py
@@ -74,6 +74,3 @@ def test_read_toast_returns_defaults_for_malformed_json() -> None:
 
     assert message == ""
     assert type_ == "success"
-
-
-

--- a/tests/page_utils_tests.py
+++ b/tests/page_utils_tests.py
@@ -1,0 +1,79 @@
+"""Tests for shared page utilities: show_toast and _read_toast_from_request."""
+
+import json
+from unittest.mock import MagicMock
+
+from starlette.responses import Response
+
+from app.routers._page_utils import _read_toast_from_request, show_toast
+
+# ---------------------------------------------------------------------------
+# show_toast()
+# ---------------------------------------------------------------------------
+
+
+def test_show_toast_sets_flash_cookie_with_default_success_type() -> None:
+    response = Response()
+
+    show_toast(response, "Vorschau erstellt")
+
+    cookie_header = response.headers.get("set-cookie", "")
+    assert "flash=" in cookie_header
+    assert "max-age=" in cookie_header.lower()
+
+
+def test_show_toast_sets_flash_cookie_with_error_type() -> None:
+    response = Response()
+
+    show_toast(response, "Pflichtfeld fehlt", "error")
+
+    cookie_header = response.headers.get("set-cookie", "")
+    assert "flash=" in cookie_header
+
+
+# ---------------------------------------------------------------------------
+# _read_toast_from_request()
+# ---------------------------------------------------------------------------
+
+
+def test_read_toast_returns_message_and_success_type() -> None:
+    request = MagicMock()
+    request.cookies = {"flash": json.dumps({"message": "Gespeichert", "type": "success"})}
+
+    message, type_ = _read_toast_from_request(request)
+
+    assert message == "Gespeichert"
+    assert type_ == "success"
+
+
+def test_read_toast_returns_message_and_error_type() -> None:
+    request = MagicMock()
+    request.cookies = {"flash": json.dumps({"message": "Fehler aufgetreten", "type": "error"})}
+
+    message, type_ = _read_toast_from_request(request)
+
+    assert message == "Fehler aufgetreten"
+    assert type_ == "error"
+
+
+def test_read_toast_returns_defaults_for_empty_cookie() -> None:
+    request = MagicMock()
+    request.cookies = {}
+
+    message, type_ = _read_toast_from_request(request)
+
+    assert message == ""
+    assert type_ == "success"
+
+
+def test_read_toast_returns_defaults_for_malformed_json() -> None:
+    request = MagicMock()
+    request.cookies = {"flash": "not-valid-json"}
+
+    message, type_ = _read_toast_from_request(request)
+
+    assert message == ""
+    assert type_ == "success"
+
+
+

--- a/tests/presence_level_service_tests.py
+++ b/tests/presence_level_service_tests.py
@@ -137,3 +137,32 @@ def test_no_push_without_service() -> None:
 
     # Should not raise
     svc._try_send_first_active_push(PresenceLevel.EMPTY, PresenceLevel.FEW)
+
+
+# ---------------------------------------------------------------------------
+# start_polling() — early return when credentials missing
+# ---------------------------------------------------------------------------
+
+
+def test_start_polling_does_not_start_when_router_ip_missing() -> None:
+    svc = _make_service()
+
+    svc.start_polling(router_ip=None, username="admin", password="pass")
+
+    assert not svc.is_polling
+
+
+def test_start_polling_does_not_start_when_username_missing() -> None:
+    svc = _make_service()
+
+    svc.start_polling(router_ip="192.168.1.1", username=None, password="pass")
+
+    assert not svc.is_polling
+
+
+def test_start_polling_does_not_start_when_password_missing() -> None:
+    svc = _make_service()
+
+    svc.start_polling(router_ip="192.168.1.1", username="admin", password=None)
+
+    assert not svc.is_polling

--- a/tests/presence_thresholds_tests.py
+++ b/tests/presence_thresholds_tests.py
@@ -1,0 +1,45 @@
+"""Tests for app.services.presence_thresholds — PresenceLevel mapping."""
+
+from pathlib import Path
+
+import pytest
+
+from app import env
+from app.services.presence_level import PresenceLevel
+from app.services.presence_thresholds import PresenceThresholds
+
+
+@pytest.fixture
+def thresholds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PresenceThresholds:
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    return PresenceThresholds()
+
+
+@pytest.mark.parametrize(
+    ("devices_ct", "expected"),
+    [
+        (0, PresenceLevel.EMPTY),
+        (1, PresenceLevel.EMPTY),
+        (2, PresenceLevel.FEW),
+        (5, PresenceLevel.FEW),
+        (9, PresenceLevel.FEW),
+        (10, PresenceLevel.MANY),
+        (100, PresenceLevel.MANY),
+    ],
+)
+def test_get_presence_level(thresholds: PresenceThresholds, devices_ct: int, expected: PresenceLevel) -> None:
+    assert thresholds.get_presence_level(devices_ct) == expected
+
+
+def test_setter_persists_min_non_empty_ct(thresholds: PresenceThresholds) -> None:
+    thresholds.min_non_empty_ct = 5
+    assert thresholds.min_non_empty_ct == 5
+    assert thresholds.get_presence_level(4) == PresenceLevel.EMPTY
+    assert thresholds.get_presence_level(5) == PresenceLevel.FEW
+
+
+def test_setter_persists_min_many_ct(thresholds: PresenceThresholds) -> None:
+    thresholds.min_many_ct = 20
+    assert thresholds.min_many_ct == 20
+    assert thresholds.get_presence_level(19) == PresenceLevel.FEW
+    assert thresholds.get_presence_level(20) == PresenceLevel.MANY

--- a/tests/redact_tests.py
+++ b/tests/redact_tests.py
@@ -1,0 +1,17 @@
+"""Tests for app.api.redact — token redaction helper."""
+
+import pytest
+
+from app.api.redact import redact_key
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        (None, "<none>"),
+        ("", "<empty>"),
+        ("abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop", "abcdefgh…"),
+    ],
+)
+def test_redact_key(key: str | None, expected: str) -> None:
+    assert redact_key(key) == expected

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -32,6 +32,7 @@ from app.dependencies import (
     get_push_subscription_service,
     get_weather_service,
 )
+from app.services.internal.warden_store import WardenStore
 from app.services.message_service import StatusMessage
 from app.services.notification_service import Notification
 from app.services.occupancy.model import DailyOccupancy, OccupancySource, OccupancyType
@@ -1492,6 +1493,7 @@ def test_wardens_list_returns_200_with_auth(
 ) -> None:
     monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
     monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    WardenStore._instance = None
 
     response = client.get("/api/internal/wardens", headers={"api_key": TEST_ADMIN_TOKEN})
 
@@ -1506,6 +1508,7 @@ def test_wardens_crud_lifecycle(
 ) -> None:
     monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
     monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    WardenStore._instance = None
     auth = {"api_key": TEST_ADMIN_TOKEN}
 
     # Create (header-based auth — no CSRF needed)
@@ -1549,6 +1552,7 @@ def test_wardens_create_duplicate_returns_409(
 ) -> None:
     monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
     monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    WardenStore._instance = None
     auth = {"api_key": TEST_ADMIN_TOKEN}
 
     client.post(
@@ -1573,6 +1577,7 @@ def test_wardens_update_not_found_returns_404(
 ) -> None:
     monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
     monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    WardenStore._instance = None
 
     response = client.put(
         "/api/internal/wardens/NonExistent",
@@ -1590,6 +1595,7 @@ def test_wardens_delete_not_found_returns_404(
 ) -> None:
     monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
     monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    WardenStore._instance = None
 
     response = client.request(
         "DELETE",
@@ -1605,7 +1611,7 @@ def test_wardens_delete_not_found_returns_404(
 # ---------------------------------------------------------------------------
 
 
-def test_config_returns_304_when_no_thresholds_sent(
+def test_config_returns_204_when_no_thresholds_sent(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1613,7 +1619,7 @@ def test_config_returns_304_when_no_thresholds_sent(
 
     response = client.patch("/api/internal/config", json={}, headers={"api_key": TEST_ADMIN_TOKEN})
 
-    assert response.status_code == 304
+    assert response.status_code == 204
 
 
 def test_config_updates_min_non_empty_ct(
@@ -1708,3 +1714,311 @@ def test_push_topics_returns_422_for_invalid_auth(client: TestClient, test_app: 
     response = client.patch("/api/push/topics", json={"auth": "", "topics": ["presence"]})
 
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /notification-create — POST form handler (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_post_notification_create_redirects_to_preview(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.add.return_value = "nid-test-123"
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/notification-create",
+        data={"message": "Hello Welt", "x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "nid-test-123" in response.headers["location"]
+    svc.add.assert_called_once()
+
+
+def test_post_notification_create_empty_message_redirects_back(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/notification-create",
+        data={"message": "   ", "x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("/notification-create")
+    svc.add.assert_not_called()
+
+
+def test_post_notification_create_invalid_date_redirects_back(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/notification-create",
+        data={"message": "Test", "valid_from": "not-a-date", "x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("/notification-create")
+    svc.add.assert_not_called()
+
+
+def test_post_notification_create_redirects_to_auth_when_unauthenticated(
+    client: TestClient,
+    test_app: FastAPI,
+) -> None:
+    svc = _mock_notification_svc()
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+
+    response = client.post("/notification-create", data={"message": "Hello"}, follow_redirects=False)
+
+    assert response.status_code in (302, 303)
+    assert "/auth" in response.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# /preview/notifications — GET preview page (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_get_notification_preview_renders_page(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    notification = MagicMock()
+    notification.id = "nid-test-abc"
+    notification.is_outdated.return_value = False
+    notification.enabled = False
+    svc.get.return_value = [notification]
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+
+    response = client.get("/preview/notifications?n_ids=nid-test-abc")
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /preview/notifications/{id}/enable — POST (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_enable_notification_redirects_to_preview(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.update.return_value = True
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-test/enable",
+        data={"x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "nid-test" in response.headers["location"]
+    svc.update.assert_called_once_with("nid-test", enabled=True)
+
+
+def test_enable_notification_returns_404_when_not_found(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.update.return_value = False
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-unknown/enable",
+        data={"x-csrf-token": csrf_token},
+    )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /preview/notifications/{id}/disable — POST (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_disable_notification_redirects_to_preview(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.update.return_value = True
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-test/disable",
+        data={"x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "nid-test" in response.headers["location"]
+    svc.update.assert_called_once_with("nid-test", enabled=False)
+
+
+def test_disable_notification_returns_404_when_not_found(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.update.return_value = False
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-unknown/disable",
+        data={"x-csrf-token": csrf_token},
+    )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /preview/notifications/{id}/delete — POST (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_notification_action_redirects_to_preview(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.delete.return_value = True
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-test/delete",
+        data={"x-csrf-token": csrf_token},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "preview/notifications" in response.headers["location"]
+    svc.delete.assert_called_once_with("nid-test")
+
+
+def test_delete_notification_action_returns_404_when_not_found(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.delete.return_value = False
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+    csrf_token = client.cookies.get("csrftoken")
+    assert csrf_token is not None
+
+    response = client.post(
+        "/preview/notifications/nid-unknown/delete",
+        data={"x-csrf-token": csrf_token},
+    )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /preview/notifications/content — GET HTML fragment (notification_ui)
+# ---------------------------------------------------------------------------
+
+
+def test_get_notification_preview_content_returns_html(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    n1 = MagicMock()
+    n1.id = "nid-1"
+    n1.message = "Hello **World**"
+    n2 = MagicMock()
+    n2.id = "nid-2"
+    n2.message = "Test"
+    svc.get.return_value = [n1, n2]
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+
+    response = client.get("/preview/notifications/content?n_ids=nid-1&n_ids=nid-2")
+
+    assert response.status_code == 200
+    assert "Hello" in response.text
+
+
+def test_get_notification_preview_content_returns_empty_when_no_notifications(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    client.post("/auth", json={"token": TEST_ADMIN_TOKEN, "next": "/"})
+    svc = _mock_notification_svc()
+    svc.get.return_value = []
+    test_app.dependency_overrides[get_notification_service] = lambda: svc
+
+    response = client.get("/preview/notifications/content?n_ids=nid-none")
+
+    assert response.status_code == 200
+    assert response.text == ""

--- a/tests/router_tests.py
+++ b/tests/router_tests.py
@@ -176,9 +176,12 @@ def test_get_auth_page_renders_password_field(client: TestClient) -> None:
 def test_index_shows_setup_banner_when_no_admin_token(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Setup banner must be visible (no 'hidden' class) when no ADMIN_TOKEN is set."""
+    monkeypatch.setattr(env, "API_KEYS_PATH", str(tmp_path / "api_keys.json"))
     monkeypatch.setattr(env, "ADMIN_TOKEN", "")
+    EphemeralAPIKeyStore.save([])
 
     response = client.get("/")
 
@@ -444,81 +447,37 @@ def test_get_legal_page_shows_push_section_when_feature_enabled(
     assert "OpenWeatherMap" not in response.text
 
 
-def test_get_legal_page_hides_push_section_when_feature_disabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("push", "presence", "weather", "expected_in", "expected_not_in"),
+    [
+        (False, False, False, [], ["Push-Benachrichtigungen", "WLAN-Anwesenheitserkennung", "OpenWeatherMap"]),
+        (False, True, False, ["WLAN-Anwesenheitserkennung", "Namentliche Zuordnung"], ["OpenWeatherMap"]),
+        (False, False, True, ["OpenWeatherMap"], ["WLAN-Anwesenheitserkennung"]),
+    ],
+    ids=["all-disabled", "presence-only", "weather-only"],
+)
+def test_get_legal_page_feature_sections(  # noqa: PLR0913
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    push: bool,  # noqa: FBT001
+    presence: bool,  # noqa: FBT001
+    weather: bool,  # noqa: FBT001
+    expected_in: list[str],
+    expected_not_in: list[str],
 ) -> None:
     monkeypatch.setattr(env, "OPERATOR_NAME", "Max Mustermann")
     monkeypatch.setattr(env, "OPERATOR_EMAIL", "max@example.com")
-    monkeypatch.setattr(env, "is_push_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_presence_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_weather_enabled", lambda: False)
+    monkeypatch.setattr(env, "is_push_enabled", lambda: push)
+    monkeypatch.setattr(env, "is_presence_enabled", lambda: presence)
+    monkeypatch.setattr(env, "is_weather_enabled", lambda: weather)
 
     response = client.get("/legal")
 
     assert response.status_code == 200
-    assert "Push-Benachrichtigungen" not in response.text
-
-
-def test_get_legal_page_shows_presence_section_when_feature_enabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(env, "OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.setattr(env, "OPERATOR_EMAIL", "max@example.com")
-    monkeypatch.setattr(env, "is_push_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_presence_enabled", lambda: True)
-    monkeypatch.setattr(env, "is_weather_enabled", lambda: False)
-
-    response = client.get("/legal")
-
-    assert response.status_code == 200
-    assert "WLAN-Anwesenheitserkennung" in response.text
-    assert "Namentliche Zuordnung" in response.text
-
-
-def test_get_legal_page_hides_presence_section_when_feature_disabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(env, "OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.setattr(env, "OPERATOR_EMAIL", "max@example.com")
-    monkeypatch.setattr(env, "is_push_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_presence_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_weather_enabled", lambda: False)
-
-    response = client.get("/legal")
-
-    assert response.status_code == 200
-    assert "WLAN-Anwesenheitserkennung" not in response.text
-    assert "Namentliche Zuordnung" not in response.text
-
-
-def test_get_legal_page_shows_weather_section_when_feature_enabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(env, "OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.setattr(env, "OPERATOR_EMAIL", "max@example.com")
-    monkeypatch.setattr(env, "is_push_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_presence_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_weather_enabled", lambda: True)
-
-    response = client.get("/legal")
-
-    assert response.status_code == 200
-    assert "OpenWeatherMap" in response.text
-
-
-def test_get_legal_page_hides_weather_section_when_feature_disabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(env, "OPERATOR_NAME", "Max Mustermann")
-    monkeypatch.setattr(env, "OPERATOR_EMAIL", "max@example.com")
-    monkeypatch.setattr(env, "is_push_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_presence_enabled", lambda: False)
-    monkeypatch.setattr(env, "is_weather_enabled", lambda: False)
-
-    response = client.get("/legal")
-
-    assert response.status_code == 200
-    assert "OpenWeatherMap" not in response.text
+    for text in expected_in:
+        assert text in response.text
+    for text in expected_not_in:
+        assert text not in response.text
 
 
 def test_index_shows_legal_link_when_operator_configured(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1453,5 +1412,299 @@ def test_create_api_key_rejects_oversized_comment(
         json={"comment": "x" * 201},
         headers=_get_csrf_headers(client),
     )
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /api/version, /api/version/content-hash, /api/licenses
+# ---------------------------------------------------------------------------
+
+
+def test_version_returns_build_version(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "BUILD_VERSION", "1.2.3")
+
+    response = client.get("/api/version")
+
+    assert response.status_code == 200
+    assert response.json()["version"] == "1.2.3"
+
+
+def test_version_content_hash_returns_hash(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "CONTENT_HASH_VERSION", "abc123")
+
+    response = client.get("/api/version/content-hash")
+
+    assert response.status_code == 200
+    assert response.json()["version"] == "abc123"
+
+
+def test_licenses_returns_list(client: TestClient) -> None:
+    response = client.get("/api/licenses")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_favicon_returns_200(client: TestClient) -> None:
+    response = client.get("/favicon.ico")
+
+    assert response.status_code == 200
+
+
+def test_service_worker_returns_js(client: TestClient) -> None:
+    response = client.get("/sw.js")
+
+    assert response.status_code == 200
+    assert "application/javascript" in response.headers["content-type"]
+    assert response.headers.get("service-worker-allowed") == "/"
+
+
+def test_robots_txt_contains_disallows(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "APP_URL", "https://example.com")
+
+    response = client.get("/robots.txt")
+
+    assert response.status_code == 200
+    assert "Disallow: /api/" in response.text
+    assert "Sitemap: https://example.com/sitemap.xml" in response.text
+
+
+def test_sitemap_xml_returns_valid_xml(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env, "APP_URL", "https://example.com")
+
+    response = client.get("/sitemap.xml")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/xml"
+    assert "<loc>https://example.com/</loc>" in response.text
+
+
+# ---------------------------------------------------------------------------
+# /api/internal/wardens — CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_wardens_list_returns_200_with_auth(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+
+    response = client.get("/api/internal/wardens", headers={"api_key": TEST_ADMIN_TOKEN})
+
+    assert response.status_code == 200
+    assert response.json()["wardens"] == []
+
+
+def test_wardens_crud_lifecycle(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    auth = {"api_key": TEST_ADMIN_TOKEN}
+
+    # Create (header-based auth — no CSRF needed)
+    response = client.post(
+        "/api/internal/wardens",
+        json={"name": "Alice", "device_macs": ["AA:BB:CC:DD:EE:FF"], "device_names": ["Phone"]},
+        headers=auth,
+    )
+    assert response.status_code == 201
+    assert response.json()["name"] == "Alice"
+
+    # List
+    client.cookies.clear()
+    wardens = client.get("/api/internal/wardens", headers=auth).json()["wardens"]
+    assert len(wardens) == 1
+
+    # Update
+    client.cookies.clear()
+    response = client.put(
+        "/api/internal/wardens/Alice",
+        json={"device_names": ["Laptop"]},
+        headers=auth,
+    )
+    assert response.status_code == 200
+    assert response.json()["device_names"] == ["laptop"]
+
+    # Delete
+    client.cookies.clear()
+    response = client.request("DELETE", "/api/internal/wardens/Alice", headers=auth)
+    assert response.status_code == 204
+
+    # Confirm deleted
+    wardens = client.get("/api/internal/wardens", headers=auth).json()["wardens"]
+    assert len(wardens) == 0
+
+
+def test_wardens_create_duplicate_returns_409(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+    auth = {"api_key": TEST_ADMIN_TOKEN}
+
+    client.post(
+        "/api/internal/wardens",
+        json={"name": "Bob", "device_macs": ["AA:BB:CC:DD:EE:FF"], "device_names": ["Phone"]},
+        headers=auth,
+    )
+    client.cookies.clear()
+    response = client.post(
+        "/api/internal/wardens",
+        json={"name": "Bob", "device_macs": ["11:22:33:44:55:66"], "device_names": ["Tab"]},
+        headers=auth,
+    )
+
+    assert response.status_code == 409
+
+
+def test_wardens_update_not_found_returns_404(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+
+    response = client.put(
+        "/api/internal/wardens/NonExistent",
+        json={"device_names": ["x"]},
+        headers={"api_key": TEST_ADMIN_TOKEN},
+    )
+
+    assert response.status_code == 404
+
+
+def test_wardens_delete_not_found_returns_404(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+
+    response = client.request(
+        "DELETE",
+        "/api/internal/wardens/NonExistent",
+        headers={"api_key": TEST_ADMIN_TOKEN},
+    )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /api/internal/config — threshold updates
+# ---------------------------------------------------------------------------
+
+
+def test_config_returns_304_when_no_thresholds_sent(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+
+    response = client.patch("/api/internal/config", json={}, headers={"api_key": TEST_ADMIN_TOKEN})
+
+    assert response.status_code == 304
+
+
+def test_config_updates_min_non_empty_ct(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+
+    response = client.patch(
+        "/api/internal/config",
+        json={"threshold_min_non_empty_ct": 5},
+        headers={"api_key": TEST_ADMIN_TOKEN},
+    )
+
+    assert response.status_code == 200
+
+
+def test_config_updates_min_many_ct(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(env, "ADMIN_TOKEN", TEST_ADMIN_TOKEN)
+    monkeypatch.setattr(env, "LOCAL_DATA_PATH", str(tmp_path))
+
+    response = client.patch(
+        "/api/internal/config",
+        json={"threshold_min_many_ct": 15},
+        headers={"api_key": TEST_ADMIN_TOKEN},
+    )
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/push — validation paths (422)
+# ---------------------------------------------------------------------------
+
+
+def test_push_status_returns_422_for_invalid_auth(client: TestClient, test_app: FastAPI) -> None:
+    push_svc = MagicMock()
+    test_app.dependency_overrides[get_push_subscription_service] = lambda: push_svc
+
+    response = client.post("/api/push/status", json={"auth": ""})
+
+    assert response.status_code == 422
+
+
+def test_push_subscribe_returns_422_for_invalid_subscription(
+    client: TestClient,
+    test_app: FastAPI,
+) -> None:
+    push_svc = MagicMock()
+    test_app.dependency_overrides[get_push_subscription_service] = lambda: push_svc
+
+    response = client.post(
+        "/api/push/subscribe",
+        json={"endpoint": "", "p256dh": "", "auth": ""},
+    )
+
+    assert response.status_code == 422
+
+
+def test_push_subscribe_returns_201_for_valid_subscription(
+    client: TestClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    push_svc = MagicMock()
+    test_app.dependency_overrides[get_push_subscription_service] = lambda: push_svc
+    monkeypatch.setattr(
+        PushSubscriptionService,
+        "validate_subscription",
+        staticmethod(lambda *_a: None),  # type: ignore[reportUnknownLambdaType]
+    )
+
+    response = client.post(
+        "/api/push/subscribe",
+        json={"endpoint": "https://push.example.com", "p256dh": "key", "auth": "auth"},
+    )
+
+    assert response.status_code == 201
+    push_svc.add.assert_called_once()
+
+
+def test_push_topics_returns_422_for_invalid_auth(client: TestClient, test_app: FastAPI) -> None:
+    push_svc = MagicMock()
+    test_app.dependency_overrides[get_push_subscription_service] = lambda: push_svc
+
+    response = client.patch("/api/push/topics", json={"auth": "", "topics": ["presence"]})
 
     assert response.status_code == 422

--- a/tests/schema_tests.py
+++ b/tests/schema_tests.py
@@ -1,0 +1,38 @@
+"""Tests for app/api/schema.py — OpenAPI schema customisation."""
+
+from fastapi import FastAPI
+
+from app.api.schema import update_openapi_schema
+
+
+def test_update_openapi_schema_registers_security_schemes() -> None:
+    app = FastAPI()
+
+    update_openapi_schema(app)
+
+    schemes = app.openapi_schema["components"]["securitySchemes"]
+    assert "APIKeyHeader" in schemes
+    assert schemes["APIKeyHeader"]["in"] == "header"
+    assert "SessionCookie" in schemes
+    assert schemes["SessionCookie"]["in"] == "cookie"
+
+
+def test_update_openapi_schema_is_idempotent() -> None:
+    app = FastAPI()
+
+    update_openapi_schema(app)
+    update_openapi_schema(app)
+
+    schemes = app.openapi_schema["components"]["securitySchemes"]
+    assert list(schemes.keys()).count("APIKeyHeader") == 1
+    assert list(schemes.keys()).count("SessionCookie") == 1
+
+
+def test_update_openapi_schema_works_when_schema_already_has_components() -> None:
+    app = FastAPI()
+    # Pre-populate openapi_schema with a components section but no securitySchemes
+    app.openapi_schema = {"openapi": "3.1.0", "info": {}, "components": {"schemas": {}}}
+
+    update_openapi_schema(app)
+
+    assert "APIKeyHeader" in app.openapi_schema["components"]["securitySchemes"]

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,37 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +511,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -660,6 +706,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "diff-cover" },
     { name = "pip-licenses" },
     { name = "pyright" },
     { name = "pytest" },
@@ -687,6 +734,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "diff-cover", specifier = ">=9.6.0" },
     { name = "pip-licenses", specifier = ">=5.5.5" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.3" },


### PR DESCRIPTION
- Isolate API key store in setup banner test (monkeypatch tmp_path)
- Add has_valid_admin_key() unit tests (empty, non-admin, expired, valid)
- Add diff-cover to CI pipeline (≥80% on new/changed lines for PRs)
- Enforce --cov-fail-under=80 in pytest CI step
- Configure [tool.coverage.run] to scope coverage to app/
- Expand and refactor router, env, and legal page tests
- Improve setup banner copy in index.html