### PR TITLE
chore(release): v0.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fribbe-status-checker"
-version = "0.5.3"
+version = "0.5.4"
 requires-python = ">=3.12"
 dependencies = [
     "huawei-lte-api>=1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "fribbe-status-checker"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.5.4

### Changes since last release

```
daf8880 chore(release): v0.5.4
2b3e8c8 chore: update lock file and licenses for v0.5.4
3681f81 fix(release): clear NODE_OPTIONS in subprocess environment for git commands
fa3f023 fix(release): add dynamic release versioning to changelog generation
430bc11 style(auth): simplify login instruction text in auth.html
f28227f refactor(redact): replace redact_key with redact for sensitive logging
c3c24b1 feat(logging): improve logging configuration and add log level support
84d6a5f chore(deps): bump Schneegans/dynamic-badges-action from 1.7.0 to 1.8.0
a57d38d chore(deps): bump actions/github-script from 7 to 9
```

Merging to `main` will trigger the CI/CD pipeline and create a stable GitHub release tagged `v0.5.4`.
