### PR TITLE
chore(release): v0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fribbe-status-checker"
-version = "0.5.4"
+version = "0.5.5"
 requires-python = ">=3.12"
 dependencies = [
     "huawei-lte-api>=1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ wheels = [
 
 [[package]]
 name = "fribbe-status-checker"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.5.5

### Changes since last release

```
e926a42 chore(release): v0.5.5
c1f50ad chore: update lock file and licenses for v0.5.5
c0002fa chore(pyright): update pyright dependency version to 1.1.409
74dc4b3 feat(test): update test commands and add test script for pytest and vitest
fd50b12 f
42d1276 feat(ci): add JavaScript testing and coverage reporting to CI/CD
e0c79d2 fix: remove dead null-check on hashString result in app.js
29b9114 ci: pin Node 22 via actions/setup-node in lint, test, and test-js jobs
9d0c58b feat(lint): add js/html linting for tests
a08a8eb test(notifications): add tests for notification dismissal logic
8790510 refactor(notifications): improve notification dismissal structure
01851a9 feat(js-testing): add frontend testing with vitest
a215fbb fix(notifications): do not remove content hash from store if no notification is supplied / on error
```

Merging to `main` will trigger the CI/CD pipeline and create a stable GitHub release tagged `v0.5.5`.
