### PR TITLE
chore(release): v0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fribbe-status-checker"
-version = "0.5.5"
+version = "0.5.6"
 requires-python = ">=3.12"
 dependencies = [
     "huawei-lte-api>=1.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "fribbe-status-checker"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v0.5.6

### Changes since last release

```
f373024 chore(release): v0.5.6
423083e chore: update lock file and licenses for v0.5.6
131aa50 test: update config tests for role-based access control
717f8db Add tests for GET /api/internal/config and update copilot-instructions.md
df1ca78 feat(api): add config response for presence detection thresholds
```

Merging to `main` will trigger the CI/CD pipeline and create a stable GitHub release tagged `v0.5.6`.
